### PR TITLE
Make function transformation type stable

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -38,7 +38,8 @@ FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLSensitivity = "1ed8b502-d754-442c-8d5d-10ac956f44a1"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["SciMLSensitivity", "FiniteDiff", "Pkg", "SafeTestsets", "Test"]
+test = ["SciMLSensitivity", "StaticArrays", "FiniteDiff", "Pkg", "SafeTestsets", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Integrals"
 uuid = "de52edbc-65ea-441a-8357-d3a637375a31"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "3.1.1"
+version = "3.1.2"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"


### PR DESCRIPTION
- Makes HCubature solve type stable with StaticArrays as bounds

```julia
μ = [0.00, 0.00]
Σ = [0.4 0.0; 0.00 0.4]
d = MvNormal(μ, Σ)
m2 = let d = d
    (x, p) -> pdf(d, x)
end

prob = IntegralProblem(m2, SVector(-Inf, -Inf), SVector(Inf, Inf))
@test_nowarn @inferred solve(prob, HCubatureJL(); do_inf_transformation = Val(true))

prob = @test_nowarn @inferred Integrals.transformation_if_inf(prob, Val(true))
@test_nowarn @inferred Integrals.__solvebp_call(prob, HCubatureJL(),
                                                Integrals.ReCallVJP(Integrals.ZygoteVJP()),
                                                prob.lb, prob.ub, prob.p)
```

CC: @ChrisRackauckas 