### PR TITLE
Clean ad

### DIFF
--- a/src/Integrals.jl
+++ b/src/Integrals.jl
@@ -18,13 +18,13 @@ end
 VEGAS(; nbins = 100, ncalls = 1000) = VEGAS(nbins, ncalls)
 
 abstract type QuadSensitivityAlg end
-struct ReCallVJP{V}
+abstract type IntegralVJP end
+struct ReCallVJP{V} <: SciMLBase.AbstractIntegralAlgorithm where V <: IntegralVJP
     vjp::V
 end
 
-abstract type IntegralVJP end
-struct ZygoteVJP end
-struct ReverseDiffVJP
+struct ZygoteVJP <: IntegralVJP end
+struct ReverseDiffVJP <: IntegralVJP
     compile::Bool
 end
 

--- a/src/Integrals.jl
+++ b/src/Integrals.jl
@@ -19,7 +19,7 @@ VEGAS(; nbins = 100, ncalls = 1000) = VEGAS(nbins, ncalls)
 
 abstract type QuadSensitivityAlg end
 abstract type IntegralVJP end
-struct ReCallVJP{V} <: SciMLBase.AbstractIntegralAlgorithm where V <: IntegralVJP
+struct ReCallVJP{V} <: SciMLBase.AbstractIntegralAlgorithm where {V <: IntegralVJP}
     vjp::V
 end
 

--- a/src/Integrals.jl
+++ b/src/Integrals.jl
@@ -292,11 +292,6 @@ function ChainRulesCore.rrule(::typeof(__solvebp), prob, alg, sensealg, lb, ub, 
     out, quadrature_adjoint
 end
 
-ZygoteRules.@adjoint function ZygoteRules.literal_getproperty(sol::SciMLBase.IntegralSolution,
-                                                              ::Val{:u})
-    sol.u, Δ -> (SciMLBase.build_solution(sol.prob, sol.alg, Δ, sol.resid),)
-end
-
 ### Forward-Mode AD Intercepts
 
 # Direct AD on solvers with QuadGK and HCubature


### PR DESCRIPTION
Abstract types were unused.
Not sure if the zygote rule is obsolete.