### PR TITLE
Simpler initial example, also highlight parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,20 @@ the documentation, which contains the unreleased features.
 
 ## Examples
 
-For basic multidimensional quadrature we can construct and solve a `IntegralProblem`:
+To perform one-dimensional quadrature, we can simply construct an `IntegralProblem`. The code below evaluates $\int_{-2}^5 \sin(xp)~\mathrm{dx}$ with $p = 1.7$. This argument $p$ is passed
+into the problem as the fourth argument of `IntegralProblem`.
+
+```julia
+using Integrals 
+f(x, p) = sin(x*p)
+p = 1.7
+prob = IntegralProblem(f, -2, 5, p)
+sol = solve(prob, QuadGKJL())
+```
+
+For basic multidimensional quadrature we can construct and solve a `IntegralProblem`. Since we are using no arguments `p` in this example, we omit the fourth argument of `IntegralProblem` 
+from above. The lower and upper bounds are now passed as vectors, with the `i`th elements of
+the bounds giving the interval of integration for `x[i]`.
 
 ```julia
 using Integrals

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ the documentation, which contains the unreleased features.
 
 ## Examples
 
-To perform one-dimensional quadrature, we can simply construct an `IntegralProblem`. The code below evaluates $\int_{-2}^5 \sin(xp)~\mathrm{dx}$ with $p = 1.7$. This argument $p$ is passed
+To perform one-dimensional quadrature, we can simply construct an `IntegralProblem`. The code below evaluates $\int_{-2}^5 \sin(xp)~\mathrm{d}x$ with $p = 1.7$. This argument $p$ is passed
 into the problem as the fourth argument of `IntegralProblem`.
 
 ```julia


### PR DESCRIPTION
The README only shows how to perform multidimensional quadrature, and doesn't mention anything about how to use parameters. This PR adds a simple one-dimensional example that also uses parameters. 

(In the actual documentation there are some examples of this, but maybe it's nice to also have it at the first thing users see. although the one-dimensional example of 

`my_sin(x) = solve(IntegralProblem((x, p) -> cos(x), 0.0, x), QuadGKJL()).u`

is a bit complicated for what users will most often want to do. Parameters are discussed in https://docs.sciml.ai/Integrals/stable/tutorials/differentiating_integrals/ which is maybe fine since it's mentioned at the start of the first tutorial.)