### PR TITLE
add segbuf to quadgkjl

### DIFF
--- a/src/Integrals.jl
+++ b/src/Integrals.jl
@@ -133,7 +133,7 @@ function __solvebp_call(prob::IntegralProblem, alg::QuadGKJL, sensealg, lb, ub, 
     p = p
     f = x -> prob.f(x, p)
     val, err = quadgk(f, lb, ub,
-                      rtol = reltol, atol = abstol, order = alg.order, norm = alg.norm)
+                      rtol = reltol, atol = abstol, order = alg.order, norm = alg.norm, segbuf = alg.segbuf)
     SciMLBase.build_solution(prob, QuadGKJL(), val, err, retcode = ReturnCode.Success)
 end
 

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -18,11 +18,12 @@ pages={1133--1145},
 year={1997}
 }
 """
-struct QuadGKJL{F} <: SciMLBase.AbstractIntegralAlgorithm where {F}
+struct QuadGKJL{F,S} <: SciMLBase.AbstractIntegralAlgorithm where {F,S}
     order::Int
     norm::F
+    segbuf::S
 end
-QuadGKJL(; order = 7, norm = norm) = QuadGKJL(order, norm)
+QuadGKJL(; order = 7, norm = norm, segbuf = nothing) = QuadGKJL(order, norm, segbuf)
 
 """
     HCubatureJL(; norm=norm, initdiv=1)


### PR DESCRIPTION
Sometimes `quadgk` is used in the inner loop of a larger calculation (such as a nested integral) and it is desirable to reduce the number of allocations it makes. This pr adds a `segbuf` field to the `QuadGKJL` algorithm to allow the user to pass in a segment buffer that reduces the amount of memory allocated by the routine when reused across calls with compatible domain, integral, and error types.

```
julia> using Integrals, QuadGK

julia> g(x, (k,)) = sin(k*x)
g (generic function with 1 method)

julia> alg = QuadGKJL(; segbuf=QuadGK.alloc_segbuf(Float64, Float64, Float64))
QuadGKJL{typeof(LinearAlgebra.norm), Vector{QuadGK.Segment{Float64, Float64, Float64}}}(7, LinearAlgebra.norm, QuadGK.Segment{Float64, Float64, Float64}[QuadGK.Segment{Float64, Float64, Float64}(0.0, 0.0, 0.0, 0.0)])

julia> solve(IntegralProblem(g, 0, 1, 80.0), QuadGKJL(; segbuf=QuadGK.alloc_segbuf(Float64, Float64, Float64)))^C

julia> @allocated solve(IntegralProblem(g, 0, 1, 80.0))
2800

julia> @allocated solve(IntegralProblem(g, 0, 1, 80.0), alg)
1072
```