### PR TITLE
draft init interface

### DIFF
--- a/src/Integrals.jl
+++ b/src/Integrals.jl
@@ -8,6 +8,7 @@ using Reexport, MonteCarloIntegration, QuadGK, HCubature
 @reexport using SciMLBase
 using LinearAlgebra
 
+include("common.jl")
 include("init.jl")
 include("algorithms.jl")
 include("infinity_handling.jl")
@@ -57,40 +58,6 @@ function checkkwargs(kwargs...)
     return nothing
 end
 
-"""
-```julia
-solve(prob::IntegralProblem, alg::SciMLBase.AbstractIntegralAlgorithm; kwargs...)
-```
-
-## Keyword Arguments
-
-The arguments to `solve` are common across all of the quadrature methods.
-These common arguments are:
-
-  - `maxiters` (the maximum number of iterations)
-  - `abstol` (absolute tolerance in changes of the objective value)
-  - `reltol` (relative tolerance  in changes of the objective value)
-"""
-function SciMLBase.solve(prob::IntegralProblem,
-                         alg::SciMLBase.AbstractIntegralAlgorithm;
-                         sensealg = ReCallVJP(ZygoteVJP()),
-                         do_inf_transformation = nothing, kwargs...)
-    checkkwargs(kwargs...)
-    prob = transformation_if_inf(prob, do_inf_transformation)
-    __solvebp(prob, alg, sensealg, prob.lb, prob.ub, prob.p; kwargs...)
-end
-# Throw error if alg is not provided, as defaults are not implemented.
-function SciMLBase.solve(::IntegralProblem; kwargs...)
-    checkkwargs(kwargs...)
-    throw(ArgumentError("""
-No integration algorithm `alg` was supplied as the second positional argument.
-Reccomended integration algorithms are:
-For scalar functions: QuadGKJL()
-For ≤ 8 dimensional vector functions: HCubatureJL()
-For > 8 dimensional vector functions: MonteCarloIntegration.vegas(f, st, en, kwargs...)
-See the docstrings of the different algorithms for more detail.
-"""))
-end
 
 # Give a layer to intercept with AD
 __solvebp(args...; kwargs...) = __solvebp_call(args...; kwargs...)

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,0 +1,71 @@
+struct IntegralCache{P,A,S,K,Tc}
+    prob::P
+    alg::A
+    sensealg::S
+    kwargs::K
+    # cache for algorithm goes here (currently unused)
+    cacheval::Tc
+    isfresh::Bool
+end
+
+function SciMLBase.init(prob::IntegralProblem,
+                        alg::SciMLBase.AbstractIntegralAlgorithm;
+                        sensealg = ReCallVJP(ZygoteVJP()),
+                        do_inf_transformation = nothing, kwargs...)
+    checkkwargs(kwargs...)
+    prob = transformation_if_inf(prob, do_inf_transformation)
+    cacheval = nothing
+    isfresh = true
+
+    IntegralCache{typeof(prob),
+                  typeof(alg),
+                  typeof(sensealg),
+                  typeof(kwargs),
+                  typeof(cacheval)}(
+                    prob,
+                    alg,
+                    sensealg,
+                    kwargs,
+                    cacheval,
+                    isfresh)
+end
+
+
+# Throw error if alg is not provided, as defaults are not implemented.
+function SciMLBase.solve(::IntegralProblem; kwargs...)
+    checkkwargs(kwargs...)
+    throw(ArgumentError("""
+No integration algorithm `alg` was supplied as the second positional argument.
+Reccomended integration algorithms are:
+For scalar functions: QuadGKJL()
+For ≤ 8 dimensional vector functions: HCubatureJL()
+For > 8 dimensional vector functions: MonteCarloIntegration.vegas(f, st, en, kwargs...)
+See the docstrings of the different algorithms for more detail.
+"""))
+end
+
+"""
+```julia
+solve(prob::IntegralProblem, alg::SciMLBase.AbstractIntegralAlgorithm; kwargs...)
+```
+
+## Keyword Arguments
+
+The arguments to `solve` are common across all of the quadrature methods.
+These common arguments are:
+
+  - `maxiters` (the maximum number of iterations)
+  - `abstol` (absolute tolerance in changes of the objective value)
+  - `reltol` (relative tolerance  in changes of the objective value)
+"""
+function SciMLBase.solve(prob::IntegralProblem,
+                         alg::SciMLBase.AbstractIntegralAlgorithm;
+                         kwargs...)
+    solve(init(prob, alg; kwargs...))
+end
+
+function SciMLBase.solve(cache::IntegralCache; kwargs...)
+    checkkwargs(kwargs...)
+    prob = cache.prob
+    __solvebp(prob, cache.alg, cache.sensealg, prob.lb, prob.ub, prob.p; cache.kwargs..., kwargs...)
+end

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,4 +1,4 @@
-struct IntegralCache{P,A,S,K,Tc}
+struct IntegralCache{P, A, S, K, Tc}
     prob::P
     alg::A
     sensealg::S
@@ -21,15 +21,13 @@ function SciMLBase.init(prob::IntegralProblem,
                   typeof(alg),
                   typeof(sensealg),
                   typeof(kwargs),
-                  typeof(cacheval)}(
-                    prob,
-                    alg,
-                    sensealg,
-                    kwargs,
-                    cacheval,
-                    isfresh)
+                  typeof(cacheval)}(prob,
+                                    alg,
+                                    sensealg,
+                                    kwargs,
+                                    cacheval,
+                                    isfresh)
 end
-
 
 # Throw error if alg is not provided, as defaults are not implemented.
 function SciMLBase.solve(::IntegralProblem; kwargs...)

--- a/src/common.jl
+++ b/src/common.jl
@@ -61,11 +61,10 @@ These common arguments are:
 function SciMLBase.solve(prob::IntegralProblem,
                          alg::SciMLBase.AbstractIntegralAlgorithm;
                          kwargs...)
-    solve(init(prob, alg; kwargs...))
+    solve!(init(prob, alg; kwargs...))
 end
 
-function SciMLBase.solve(cache::IntegralCache; kwargs...)
-    checkkwargs(kwargs...)
+function SciMLBase.solve!(cache::IntegralCache)
     prob = cache.prob
-    __solvebp(prob, cache.alg, cache.sensealg, prob.lb, prob.ub, prob.p; cache.kwargs..., kwargs...)
+    __solvebp(prob, cache.alg, cache.sensealg, prob.lb, prob.ub, prob.p; cache.kwargs...)
 end


### PR DESCRIPTION
This pr drafts the [SciML `init` interface](https://docs.sciml.ai/SciMLBase/stable/interfaces/Init_Solve/#init-and-the-Iterator-Interface) for Integrals.jl. In the same style as LinearSolve.jl, `init` creates a cache based on the problem and algorithm. Currently the cache is unused because I just wanted to start with a minimal working version of the interface before changing anything at large.