### PR TITLE
Fix AD for parameters

### DIFF
--- a/ext/IntegralsForwardDiffExt.jl
+++ b/ext/IntegralsForwardDiffExt.jl
@@ -29,7 +29,7 @@ function Integrals.__solvebp(cache, alg, sensealg, lb, ub,
         dfdp = function (out, x, p)
             dualp = reinterpret(ForwardDiff.Dual{T, V, P}, p)
             if cache.batch > 0
-                dx = similar(dualp, cache.nout, size(x, 2))
+                dx = cache.nout == 1 ? similar(dualp, size(x, ndims(x))) : similar(dualp, cache.nout, size(x, ndims(x)))
             else
                 dx = similar(dualp, cache.nout)
             end
@@ -49,7 +49,7 @@ function Integrals.__solvebp(cache, alg, sensealg, lb, ub,
             dualp = reinterpret(ForwardDiff.Dual{T, V, P}, p)
             ys = cache.f(x, dualp)
             if cache.batch > 0
-                out = similar(p, V, nout, size(x, 2))
+                out = similar(p, V, nout, size(x, ndims(x)))
             else
                 out = similar(p, V, nout)
             end

--- a/ext/IntegralsForwardDiffExt.jl
+++ b/ext/IntegralsForwardDiffExt.jl
@@ -29,7 +29,8 @@ function Integrals.__solvebp(cache, alg, sensealg, lb, ub,
         dfdp = function (out, x, p)
             dualp = reinterpret(ForwardDiff.Dual{T, V, P}, p)
             if cache.batch > 0
-                dx = cache.nout == 1 ? similar(dualp, size(x, ndims(x))) : similar(dualp, cache.nout, size(x, ndims(x)))
+                dx = cache.nout == 1 ? similar(dualp, size(x, ndims(x))) :
+                     similar(dualp, cache.nout, size(x, ndims(x)))
             else
                 dx = similar(dualp, cache.nout)
             end

--- a/ext/IntegralsZygoteExt.jl
+++ b/ext/IntegralsZygoteExt.jl
@@ -3,37 +3,44 @@ using Integrals
 if isdefined(Base, :get_extension)
     using Zygote
     import ChainRulesCore
-    import ChainRulesCore: NoTangent
+    import ChainRulesCore: NoTangent, ProjectTo
 else
     using ..Zygote
     import ..Zygote.ChainRulesCore
-    import ..Zygote.ChainRulesCore: NoTangent
+    import ..Zygote.ChainRulesCore: NoTangent, ProjectTo
 end
 ChainRulesCore.@non_differentiable Integrals.checkkwargs(kwargs...)
+ChainRulesCore.@non_differentiable Integrals.isinplace(f, n)    # fixes #99
 
 function ChainRulesCore.rrule(::typeof(Integrals.__solvebp), cache, alg, sensealg, lb, ub,
     p;
     kwargs...)
     out = Integrals.__solvebp_call(cache, alg, sensealg, lb, ub, p; kwargs...)
 
+    # the adjoint will be the integral of the input sensitivities, so it maps the
+    # sensitivity of the output to an object of the type of the parameters
     function quadrature_adjoint(Δ)
-        y = typeof(Δ) <: Array{<:Number, 0} ? Δ[1] : Δ
+        # https://juliadiff.org/ChainRulesCore.jl/dev/design/many_tangents.html#manytypes
+        y = cache.nout == 1 ? Δ[1] : Δ   # interpret the output as scalar
+        # this will not be type-stable, but I believe it is unavoidable due to two ambiguities:
+        # 1. Δ is the output of the algorithm, and when nout = 1 it is undefined whether the
+        #    output of the algorithm must be a scalar or a vector of length 1
+        # 2. when nout = 1 the integrand can either be a scalar or a vector of length 1
         if isinplace(cache)
             dx = zeros(cache.nout)
             _f = x -> cache.f(dx, x, p)
             if sensealg.vjp isa Integrals.ZygoteVJP
                 dfdp = function (dx, x, p)
-                    _, back = Zygote.pullback(p) do p
-                        _dx = Zygote.Buffer(x, cache.nout, size(x, 2))
+                    z, back = Zygote.pullback(p) do p
+                        _dx = cache.nout == 1 ? Zygote.Buffer(dx, eltype(y), size(x, ndims(x))) : Zygote.Buffer(dx, eltype(y), cache.nout, size(x, ndims(x)))
                         cache.f(_dx, x, p)
                         copy(_dx)
                     end
-
-                    z = zeros(size(x, 2))
-                    for idx in 1:size(x, 2)
-                        z[1] = 1
-                        dx[:, idx] = back(z)[1]
-                        z[idx] = 0
+                    z .= zero(eltype(z))
+                    for idx in 1:size(x, ndims(x))
+                        z isa Vector ? (z[idx] = y) : (z[:,idx] .= y)
+                        dx[:, idx] .= back(z)[1]
+                        z isa Vector ? (z[idx] = zero(eltype(z))) : (z[:, idx] .= zero(eltype(z)))
                     end
                 end
             elseif sensealg.vjp isa Integrals.ReverseDiffVJP
@@ -44,14 +51,19 @@ function ChainRulesCore.rrule(::typeof(Integrals.__solvebp), cache, alg, senseal
             if sensealg.vjp isa Integrals.ZygoteVJP
                 if cache.batch > 0
                     dfdp = function (x, p)
-                        _, back = Zygote.pullback(p -> cache.f(x, p), p)
+                        z, back = Zygote.pullback(p -> cache.f(x, p), p)
+                        # messy, there are 4 cases, some better in forward mode than reverse
+                        # 1: length(y) == 1 and length(p) == 1
+                        # 2: length(y) >  1 and length(p) == 1
+                        # 3: length(y) == 1 and length(p) >  1
+                        # 4: length(y) >  1 and length(p) >  1
 
-                        out = zeros(length(p), size(x, 2))
-                        z = zeros(size(x, 2))
-                        for idx in 1:size(x, 2)
-                            z[idx] = 1
-                            out[:, idx] = back(z)[1]
-                            z[idx] = 0
+                        z .= zero(eltype(z))
+                        out = zeros(eltype(p), size(p)..., size(x, ndims(x)))
+                        for idx in 1:size(x, ndims(x))
+                            z isa Vector ? (z[idx] = y) : (z[:, idx] .= y)
+                            out isa Vector ? (out[idx] = back(z)[1]) : (out[:, idx] .= back(z)[1])
+                            z isa Vector ? (z[idx] = zero(y)) : (z[:, idx] .= zero(eltype(y)))
                         end
                         out
                     end
@@ -76,17 +88,24 @@ function ChainRulesCore.rrule(::typeof(Integrals.__solvebp), cache, alg, senseal
             do_inf_transformation = Val(false),
             cache.kwargs...)
 
-        if p isa Number
-            dp = Integrals.__solvebp_call(dp_cache, alg, sensealg, lb, ub, p; kwargs...)[1]
-        else
-            dp = Integrals.__solvebp_call(dp_cache, alg, sensealg, lb, ub, p; kwargs...).u
-        end
+        project_p = ProjectTo(p)
+        dp = project_p(Integrals.__solvebp_call(dp_cache, alg, sensealg, lb, ub, p; kwargs...).u)
 
         if lb isa Number
-            dlb = -_f(lb)
-            dub = _f(ub)
+            dlb = cache.batch > 0 ? -_f([lb]) : -_f(lb)
+            dub = cache.batch > 0 ? _f([ub]) : _f(ub)
             return (NoTangent(), NoTangent(), NoTangent(), NoTangent(), dlb, dub, dp)
         else
+            # we need to compute 2*length(lb) integrals on the faces of the hypercube, as we
+            # can see from writing the multidimensional integral as an iterated integral
+            # alternatively we can use Stokes' theorem to replace the integral on the
+            # boundary with a volume integral of the flux of the integrand
+            # ∫∂Ω ω = ∫Ω dω, which would be better since we won't have to change the
+            # dimensionality of the integral or the quadrature used (such as quadratures
+            # that don't evaluate points on the boundaries) and it could be generalized to
+            # other kinds of domains. The only question is to determine ω in terms of f and
+            # the deformation of the surface (e.g. consider integral over an ellipse and
+            # asking for the derivative of the result w.r.t. the semiaxes of the ellipse)
             return (NoTangent(), NoTangent(), NoTangent(), NoTangent(), NoTangent(),
                 NoTangent(), dp)
         end
@@ -94,8 +113,8 @@ function ChainRulesCore.rrule(::typeof(Integrals.__solvebp), cache, alg, senseal
     out, quadrature_adjoint
 end
 
-Zygote.@adjoint function Zygote.literal_getproperty(sol::SciMLBase.IntegralSolution,
-    ::Val{:u})
-    sol.u, Δ -> (SciMLBase.build_solution(sol.prob, sol.alg, Δ, sol.resid),)
-end
+# Zygote.@adjoint function Zygote.literal_getproperty(sol::SciMLBase.IntegralSolution,
+#     ::Val{:u})
+#     sol.u, Δ -> (SciMLBase.build_solution(sol.prob, sol.alg, Δ, sol.resid),)
+# end
 end

--- a/ext/IntegralsZygoteExt.jl
+++ b/ext/IntegralsZygoteExt.jl
@@ -124,8 +124,8 @@ function ChainRulesCore.rrule(::typeof(Integrals.__solvebp), cache, alg, senseal
     out, quadrature_adjoint
 end
 
-# Zygote.@adjoint function Zygote.literal_getproperty(sol::SciMLBase.IntegralSolution,
-#     ::Val{:u})
-#     sol.u, Δ -> (SciMLBase.build_solution(sol.prob, sol.alg, Δ, sol.resid),)
-# end
+Zygote.@adjoint function Zygote.literal_getproperty(sol::SciMLBase.IntegralSolution,
+    ::Val{:u})
+    sol.u, Δ -> (SciMLBase.build_solution(sol.prob, sol.alg, Δ, sol.resid),)
+end
 end

--- a/ext/IntegralsZygoteExt.jl
+++ b/ext/IntegralsZygoteExt.jl
@@ -32,15 +32,18 @@ function ChainRulesCore.rrule(::typeof(Integrals.__solvebp), cache, alg, senseal
             if sensealg.vjp isa Integrals.ZygoteVJP
                 dfdp = function (dx, x, p)
                     z, back = Zygote.pullback(p) do p
-                        _dx = cache.nout == 1 ? Zygote.Buffer(dx, eltype(y), size(x, ndims(x))) : Zygote.Buffer(dx, eltype(y), cache.nout, size(x, ndims(x)))
+                        _dx = cache.nout == 1 ?
+                              Zygote.Buffer(dx, eltype(y), size(x, ndims(x))) :
+                              Zygote.Buffer(dx, eltype(y), cache.nout, size(x, ndims(x)))
                         cache.f(_dx, x, p)
                         copy(_dx)
                     end
                     z .= zero(eltype(z))
                     for idx in 1:size(x, ndims(x))
-                        z isa Vector ? (z[idx] = y) : (z[:,idx] .= y)
+                        z isa Vector ? (z[idx] = y) : (z[:, idx] .= y)
                         dx[:, idx] .= back(z)[1]
-                        z isa Vector ? (z[idx] = zero(eltype(z))) : (z[:, idx] .= zero(eltype(z)))
+                        z isa Vector ? (z[idx] = zero(eltype(z))) :
+                        (z[:, idx] .= zero(eltype(z)))
                     end
                 end
             elseif sensealg.vjp isa Integrals.ReverseDiffVJP
@@ -62,8 +65,10 @@ function ChainRulesCore.rrule(::typeof(Integrals.__solvebp), cache, alg, senseal
                         out = zeros(eltype(p), size(p)..., size(x, ndims(x)))
                         for idx in 1:size(x, ndims(x))
                             z isa Vector ? (z[idx] = y) : (z[:, idx] .= y)
-                            out isa Vector ? (out[idx] = back(z)[1]) : (out[:, idx] .= back(z)[1])
-                            z isa Vector ? (z[idx] = zero(y)) : (z[:, idx] .= zero(eltype(y)))
+                            out isa Vector ? (out[idx] = back(z)[1]) :
+                            (out[:, idx] .= back(z)[1])
+                            z isa Vector ? (z[idx] = zero(y)) :
+                            (z[:, idx] .= zero(eltype(y)))
                         end
                         out
                     end
@@ -89,7 +94,13 @@ function ChainRulesCore.rrule(::typeof(Integrals.__solvebp), cache, alg, senseal
             cache.kwargs...)
 
         project_p = ProjectTo(p)
-        dp = project_p(Integrals.__solvebp_call(dp_cache, alg, sensealg, lb, ub, p; kwargs...).u)
+        dp = project_p(Integrals.__solvebp_call(dp_cache,
+            alg,
+            sensealg,
+            lb,
+            ub,
+            p;
+            kwargs...).u)
 
         if lb isa Number
             dlb = cache.batch > 0 ? -_f([lb]) : -_f(lb)

--- a/lib/IntegralsCubature/src/IntegralsCubature.jl
+++ b/lib/IntegralsCubature/src/IntegralsCubature.jl
@@ -85,7 +85,6 @@ function Integrals.__solvebp_call(prob::IntegralProblem,
                         reltol = reltol, abstol = abstol,
                         maxevals = maxiters)
                 end
-
             end
         else
             if isinplace(prob)

--- a/lib/IntegralsCubature/src/IntegralsCubature.jl
+++ b/lib/IntegralsCubature/src/IntegralsCubature.jl
@@ -54,6 +54,10 @@ function Integrals.__solvebp_call(prob::IntegralProblem,
     maxiters = typemax(Int))
     nout = prob.nout
     if nout == 1
+        # the output of prob.f could be either scalar or a vector of length 1, however
+        # the behavior of the output of the integration routine is undefined (could differ
+        # across algorithms)
+        # Cubature will output a real number in when called without nout/fdim
         if prob.batch == 0
             if isinplace(prob)
                 dx = zeros(eltype(lb), prob.nout)
@@ -63,74 +67,53 @@ function Integrals.__solvebp_call(prob::IntegralProblem,
             end
             if lb isa Number
                 if alg isa CubatureJLh
-                    _val, err = Cubature.hquadrature(f, lb, ub;
+                    val, err = Cubature.hquadrature(f, lb, ub;
                         reltol = reltol, abstol = abstol,
                         maxevals = maxiters)
                 else
-                    _val, err = Cubature.pquadrature(f, lb, ub;
+                    val, err = Cubature.pquadrature(f, lb, ub;
                         reltol = reltol, abstol = abstol,
                         maxevals = maxiters)
                 end
-                val = prob.f(lb, p) isa Number ? _val : [_val]
             else
                 if alg isa CubatureJLh
-                    _val, err = Cubature.hcubature(f, lb, ub;
+                    val, err = Cubature.hcubature(f, lb, ub;
                         reltol = reltol, abstol = abstol,
                         maxevals = maxiters)
                 else
-                    _val, err = Cubature.pcubature(f, lb, ub;
+                    val, err = Cubature.pcubature(f, lb, ub;
                         reltol = reltol, abstol = abstol,
                         maxevals = maxiters)
                 end
 
-                if isinplace(prob) || !isa(prob.f(lb, p), Number)
-                    val = [_val]
-                else
-                    val = _val
-                end
             end
         else
             if isinplace(prob)
-                f = (x, dx) -> prob.f(dx', x, p)
-            elseif lb isa Number
-                if prob.f([lb ub], p) isa Vector
-                    f = (x, dx) -> (dx .= prob.f(x', p))
-                else
-                    f = function (x, dx)
-                        dx[:] = prob.f(x', p)
-                    end
-                end
+                f = (x, dx) -> prob.f(dx, x, p)
             else
-                if prob.f([lb ub], p) isa Vector
-                    f = (x, dx) -> (dx .= prob.f(x, p))
-                else
-                    f = function (x, dx)
-                        dx .= prob.f(x, p)[:]
-                    end
-                end
+                f = (x, dx) -> (dx .= prob.f(x, p))
             end
             if lb isa Number
                 if alg isa CubatureJLh
-                    _val, err = Cubature.hquadrature_v(f, lb, ub;
+                    val, err = Cubature.hquadrature_v(f, lb, ub;
                         reltol = reltol, abstol = abstol,
                         maxevals = maxiters)
                 else
-                    _val, err = Cubature.pquadrature_v(f, lb, ub;
+                    val, err = Cubature.pquadrature_v(f, lb, ub;
                         reltol = reltol, abstol = abstol,
                         maxevals = maxiters)
                 end
             else
                 if alg isa CubatureJLh
-                    _val, err = Cubature.hcubature_v(f, lb, ub;
+                    val, err = Cubature.hcubature_v(f, lb, ub;
                         reltol = reltol, abstol = abstol,
                         maxevals = maxiters)
                 else
-                    _val, err = Cubature.pcubature_v(f, lb, ub;
+                    val, err = Cubature.pcubature_v(f, lb, ub;
                         reltol = reltol, abstol = abstol,
                         maxevals = maxiters)
                 end
             end
-            val = _val isa Number ? [_val] : _val
         end
     else
         if prob.batch == 0
@@ -166,13 +149,9 @@ function Integrals.__solvebp_call(prob::IntegralProblem,
             end
         else
             if isinplace(prob)
-                f = (x, dx) -> prob.f(dx, x, p)
+                f = (x, dx) -> (prob.f(dx, x, p); dx)
             else
-                if lb isa Number
-                    f = (x, dx) -> (dx .= prob.f(x', p))
-                else
-                    f = (x, dx) -> (dx .= prob.f(x, p))
-                end
+                f = (x, dx) -> (dx .= prob.f(x, p))
             end
 
             if lb isa Number

--- a/test/derivative_tests.jl
+++ b/test/derivative_tests.jl
@@ -1,4 +1,4 @@
-using Integrals, Zygote, FiniteDiff, ForwardDiff, SciMLSensitivity
+using Integrals, Zygote, FiniteDiff, ForwardDiff#, SciMLSensitivity
 using IntegralsCuba, IntegralsCubature
 using Test
 
@@ -117,7 +117,7 @@ dp4 = ForwardDiff.gradient(p -> testf(lb, ub, p), p)
 @test dp1 ≈ dp4
 
 ### Batch Single dim
-f(x, p) = x * p[1] .+ p[2] * p[3]
+f(x, p) = x * p[1] .+ p[2] * p[3]  # scalar integrand
 
 lb = 1.0
 ub = 3.0
@@ -130,14 +130,14 @@ function testf3(lb, ub, p; f = f)
 end
 
 dp1 = ForwardDiff.gradient(p -> testf3(lb, ub, p), p)
-# dp2 = Zygote.gradient(p->testf3(lb,ub,p),p)[1] # TODO fix: LoadError: DimensionMismatch("variable with size(x) == (1, 15) cannot have a gradient with size(dx) == (15,)")
+dp2 = Zygote.gradient(p->testf3(lb,ub,p),p)[1] # TODO fix: LoadError: DimensionMismatch("variable with size(x) == (1, 15) cannot have a gradient with size(dx) == (15,)")
 dp3 = FiniteDiff.finite_difference_gradient(p -> testf3(lb, ub, p), p)
 
 @test dp1 ≈ dp3 #passes
-@test_broken dp2 ≈ dp3 #passes
+@test dp2 ≈ dp3 #passes
 
 ### Batch single dim, nout
-f(x, p) = (x * p[1] .+ p[2] * p[3]) .* [1; 2]
+f(x, p) = (x' * p[1] .+ p[2] * p[3]) .* [1; 2]
 
 lb = 1.0
 ub = 3.0
@@ -150,11 +150,11 @@ function testf3(lb, ub, p; f = f)
 end
 
 dp1 = ForwardDiff.gradient(p -> testf3(lb, ub, p), p)
-# dp2 = Zygote.gradient(p->testf3(lb,ub,p),p)[1]
+dp2 = Zygote.gradient(p->testf3(lb,ub,p),p)[1]
 dp3 = FiniteDiff.finite_difference_gradient(p -> testf3(lb, ub, p), p)
 
 @test dp1 ≈ dp3 #passes
-# @test dp2 ≈ dp3 #passes
+@test dp2 ≈ dp3 #passes
 
 ### Batch multi dim
 f(x, p) = x[1, :] * p[1] .+ p[2] * p[3]
@@ -190,15 +190,15 @@ function testf3(lb, ub, p; f = f)
 end
 
 dp1 = ForwardDiff.gradient(p -> testf3(lb, ub, p), p)
-# dp2 = Zygote.gradient(p->testf3(lb,ub,p),p)[1]
+dp2 = Zygote.gradient(p->testf3(lb,ub,p),p)[1]
 dp3 = FiniteDiff.finite_difference_gradient(p -> testf3(lb, ub, p), p)
 
 @test dp1 ≈ dp3
-# @test dp2 ≈ dp3 
+@test dp2 ≈ dp3
 
-## iip Batch mulit dim
+## iip Batch multi dim
 function g(dx, x, p)
-    dx .= sum(x * p[1] .+ p[2] * p[3], dims = 1)
+    dx .= dropdims(sum(x * p[1] .+ p[2] * p[3], dims = 1), dims = 1)
 end
 
 lb = [1.0, 1.0]
@@ -236,8 +236,8 @@ function testf3(lb, ub, p; f = g)
 end
 
 dp1 = ForwardDiff.gradient(p -> testf3(lb, ub, p), p)
-# dp2 = Zygote.gradient(p->testf3(lb,ub,p),p)[1]
+dp2 = Zygote.gradient(p->testf3(lb,ub,p),p)[1]
 dp3 = FiniteDiff.finite_difference_gradient(p -> testf3(lb, ub, p), p)
 
 @test dp1 ≈ dp3
-# @test dp2 ≈ dp3 
+@test dp2 ≈ dp3

--- a/test/derivative_tests.jl
+++ b/test/derivative_tests.jl
@@ -130,7 +130,7 @@ function testf3(lb, ub, p; f = f)
 end
 
 dp1 = ForwardDiff.gradient(p -> testf3(lb, ub, p), p)
-dp2 = Zygote.gradient(p->testf3(lb,ub,p),p)[1] # TODO fix: LoadError: DimensionMismatch("variable with size(x) == (1, 15) cannot have a gradient with size(dx) == (15,)")
+dp2 = Zygote.gradient(p -> testf3(lb, ub, p), p)[1] # TODO fix: LoadError: DimensionMismatch("variable with size(x) == (1, 15) cannot have a gradient with size(dx) == (15,)")
 dp3 = FiniteDiff.finite_difference_gradient(p -> testf3(lb, ub, p), p)
 
 @test dp1 ≈ dp3 #passes
@@ -150,7 +150,7 @@ function testf3(lb, ub, p; f = f)
 end
 
 dp1 = ForwardDiff.gradient(p -> testf3(lb, ub, p), p)
-dp2 = Zygote.gradient(p->testf3(lb,ub,p),p)[1]
+dp2 = Zygote.gradient(p -> testf3(lb, ub, p), p)[1]
 dp3 = FiniteDiff.finite_difference_gradient(p -> testf3(lb, ub, p), p)
 
 @test dp1 ≈ dp3 #passes
@@ -190,7 +190,7 @@ function testf3(lb, ub, p; f = f)
 end
 
 dp1 = ForwardDiff.gradient(p -> testf3(lb, ub, p), p)
-dp2 = Zygote.gradient(p->testf3(lb,ub,p),p)[1]
+dp2 = Zygote.gradient(p -> testf3(lb, ub, p), p)[1]
 dp3 = FiniteDiff.finite_difference_gradient(p -> testf3(lb, ub, p), p)
 
 @test dp1 ≈ dp3
@@ -236,7 +236,7 @@ function testf3(lb, ub, p; f = g)
 end
 
 dp1 = ForwardDiff.gradient(p -> testf3(lb, ub, p), p)
-dp2 = Zygote.gradient(p->testf3(lb,ub,p),p)[1]
+dp2 = Zygote.gradient(p -> testf3(lb, ub, p), p)[1]
 dp3 = FiniteDiff.finite_difference_gradient(p -> testf3(lb, ub, p), p)
 
 @test dp1 ≈ dp3


### PR DESCRIPTION
This pr should fix #99 but in writing this I ran into a lot of internal inconsistencies in Integrals.jl as to how it handles the behavior of nout, batch, and inplace integration (as defined in the docs for `IntegralProblem`). Moreover, there are two ambiguities that mean I can't make autodiff type stable:
1. When nout = 1, batch = 0, and not inplace, it is unclear whether the integrand returns a scalar or a vector of length one
2. When nout = 1 and not inplace, it is unclear if the algorithm should return a scalar or a vector of length 1. In fact the different algorithms make different choices.

This pr also creates breaking changes in IntegralsCubature.jl because a) it did not follow the interface in the docs (i.e. in places it used adjoints to turn vectors into matrices where it was not supposed to) and b) I changed the default choice regarding point 2. above to return a scalar when nout = 1.

In light of these points, I advocate for merging this pr, and also making the following changes in the next breaking release of Integrals.jl
* Features of inplace integrands, `nout`, and `batch` should be replaced by specialized integrand wrappers that allow the user to provide the output (and input) arrays of the correct Julia types, which can be arbitrary. (I believe this is the right abstraction and have implemented it in https://github.com/lxvm/AutoBZCore.jl)
* It seems like `IntegralSolution`s are treated like arrays, so we should decide how to interpret the output of algorithms in terms of this so we can write type-stable pullbacks.
* The C library wrappers (i.e. IntegralsCuba.jl and IntegralsCubature.jl), which have restricted integrand types of floats or float arrays, may need their own AD package extensions if we would like to implement more efficient pullbacks for pure Julia packages with more generic types. For example, it would be nice to calculate the integral of a function over an ellipse and calculate its partials w.r.t. the semiaxes of the ellipse. I don't see anything preventing this in a pure Julia implementation, but the code may have to be different from the C code.
* Is it possible to replace the `sensealg` argument with different AD backends provided by AbstractDifferentiation.jl?

Thanks in advance for your help.