### PR TITLE
add --QuadratureFunction-- QuadratureRule

### DIFF
--- a/docs/src/solvers/IntegralSolvers.md
+++ b/docs/src/solvers/IntegralSolvers.md
@@ -12,10 +12,12 @@ The following algorithms are available:
   - `CubaDivonne`: Divonne from Cuba.jl. Requires `using IntegralsCuba`. Works only for `>1`-dimensional integrations.
   - `CubaCuhre`: Cuhre from Cuba.jl. Requires `using IntegralsCuba`. Works only for `>1`-dimensional integrations.
   - `GaussLegendre`: Uses Gauss-Legendre quadrature with nodes and weights from FastGaussQuadrature.jl.
+  - `QuadratureFunction`: Accepts a user-defined function that returns nodes and weights.
 
 ```@docs
 QuadGKJL
 HCubatureJL
 VEGAS
 GaussLegendre
+QuadratureFunction
 ```

--- a/docs/src/solvers/IntegralSolvers.md
+++ b/docs/src/solvers/IntegralSolvers.md
@@ -19,5 +19,5 @@ QuadGKJL
 HCubatureJL
 VEGAS
 GaussLegendre
-QuadratureFunction
+QuadratureRule
 ```

--- a/docs/src/solvers/IntegralSolvers.md
+++ b/docs/src/solvers/IntegralSolvers.md
@@ -12,7 +12,7 @@ The following algorithms are available:
   - `CubaDivonne`: Divonne from Cuba.jl. Requires `using IntegralsCuba`. Works only for `>1`-dimensional integrations.
   - `CubaCuhre`: Cuhre from Cuba.jl. Requires `using IntegralsCuba`. Works only for `>1`-dimensional integrations.
   - `GaussLegendre`: Uses Gauss-Legendre quadrature with nodes and weights from FastGaussQuadrature.jl.
-  - `QuadratureFunction`: Accepts a user-defined function that returns nodes and weights.
+  - `QuadratureRule`: Accepts a user-defined function that returns nodes and weights.
 
 ```@docs
 QuadGKJL

--- a/src/Integrals.jl
+++ b/src/Integrals.jl
@@ -148,5 +148,5 @@ function __solvebp_call(prob::IntegralProblem, alg::VEGAS, sensealg, lb, ub, p;
     SciMLBase.build_solution(prob, alg, val, err, chi = chi, retcode = ReturnCode.Success)
 end
 
-export QuadGKJL, HCubatureJL, VEGAS, GaussLegendre, QuadratureFunction
+export QuadGKJL, HCubatureJL, VEGAS, GaussLegendre, QuadratureRule
 end # module

--- a/src/Integrals.jl
+++ b/src/Integrals.jl
@@ -12,6 +12,7 @@ include("common.jl")
 include("init.jl")
 include("algorithms.jl")
 include("infinity_handling.jl")
+include("quadrules.jl")
 
 abstract type QuadSensitivityAlg end
 struct ReCallVJP{V}
@@ -147,5 +148,5 @@ function __solvebp_call(prob::IntegralProblem, alg::VEGAS, sensealg, lb, ub, p;
     SciMLBase.build_solution(prob, alg, val, err, chi = chi, retcode = ReturnCode.Success)
 end
 
-export QuadGKJL, HCubatureJL, VEGAS, GaussLegendre
+export QuadGKJL, HCubatureJL, VEGAS, GaussLegendre, QuadratureFunction
 end # module

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -127,7 +127,11 @@ end
     QuadratureFunction(q; n=250)
 
 Algorithm to construct and evaluate a quadrature rule `q` of `n` points computed from the
-inputs as `x, w = q(n)`
+inputs as `x, w = q(n)`. It assumes the nodes and weights are for the standard interval
+`[-1, 1]^d` in `d` dimensions, and rescales the nodes to the specific hypercube being
+solved. The nodes `x` may be scalars in 1d or vectors in arbitrary dimensions, and the
+weights `w` must be scalar. The algorithm computes the quadrature rule `sum(w .* f.(x))` and
+the caller must check that the result is converged with respect to `n`.
 """
 struct QuadratureFunction{Q} <: SciMLBase.AbstractIntegralAlgorithm
     q::Q

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -122,3 +122,20 @@ function GaussLegendre(; n = 250, subintervals = 1, nodes = nothing, weights = n
     end
     return GaussLegendre(nodes, weights, subintervals)
 end
+
+"""
+    QuadratureFunction(q; n=250)
+
+Algorithm to construct and evaluate a quadrature rule `q` of `n` points computed from the
+inputs as `x, w = q(n)`
+"""
+struct QuadratureFunction{Q} <: SciMLBase.AbstractIntegralAlgorithm
+    q::Q
+    n::Int
+    function QuadratureFunction(q::Q, n::Integer) where {Q}
+        n > 0 ||
+            throw(ArgumentError("Cannot use a nonpositive number of quadrature nodes."))
+        return new{Q}(q, n)
+    end
+end
+QuadratureFunction(q; n = 250) = QuadratureFunction(q, n)

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -124,7 +124,7 @@ function GaussLegendre(; n = 250, subintervals = 1, nodes = nothing, weights = n
 end
 
 """
-    QuadratureFunction(q; n=250)
+    QuadratureRule(q; n=250)
 
 Algorithm to construct and evaluate a quadrature rule `q` of `n` points computed from the
 inputs as `x, w = q(n)`. It assumes the nodes and weights are for the standard interval
@@ -133,13 +133,13 @@ solved. The nodes `x` may be scalars in 1d or vectors in arbitrary dimensions, a
 weights `w` must be scalar. The algorithm computes the quadrature rule `sum(w .* f.(x))` and
 the caller must check that the result is converged with respect to `n`.
 """
-struct QuadratureFunction{Q} <: SciMLBase.AbstractIntegralAlgorithm
+struct QuadratureRule{Q} <: SciMLBase.AbstractIntegralAlgorithm
     q::Q
     n::Int
-    function QuadratureFunction(q::Q, n::Integer) where {Q}
+    function QuadratureRule(q::Q, n::Integer) where {Q}
         n > 0 ||
             throw(ArgumentError("Cannot use a nonpositive number of quadrature nodes."))
         return new{Q}(q, n)
     end
 end
-QuadratureFunction(q; n = 250) = QuadratureFunction(q, n)
+QuadratureRule(q; n = 250) = QuadratureRule(q, n)

--- a/src/quadrules.jl
+++ b/src/quadrules.jl
@@ -18,20 +18,19 @@ function evalrule(f, p, lb, ub, nodes, weights)
     return prod(scale) * I
 end
 
-function init_cacheval(alg::QuadratureFunction, ::IntegralProblem)
+function init_cacheval(alg::QuadratureRule, ::IntegralProblem)
     return alg.q(alg.n)
 end
 
-function Integrals.__solvebp_call(cache::IntegralCache, alg::QuadratureFunction,
+function Integrals.__solvebp_call(cache::IntegralCache, alg::QuadratureRule,
     sensealg, lb, ub, p;
     reltol = nothing, abstol = nothing,
     maxiters = nothing)
     prob = build_problem(cache)
     if isinplace(prob)
-        error("QuadratureFunction does not support inplace integrandss.")
+        error("QuadratureRule does not support inplace integrandss.")
     end
     @assert prob.batch == 0
-    @assert prob.nout == 1
 
     val = evalrule(cache.f, cache.p, lb, ub, cache.cacheval...)
 

--- a/src/quadrules.jl
+++ b/src/quadrules.jl
@@ -28,7 +28,7 @@ function Integrals.__solvebp_call(cache::IntegralCache, alg::QuadratureRule,
     maxiters = nothing)
     prob = build_problem(cache)
     if isinplace(prob)
-        error("QuadratureRule does not support inplace integrandss.")
+        error("QuadratureRule does not support inplace integrands.")
     end
     @assert prob.batch == 0
 

--- a/src/quadrules.jl
+++ b/src/quadrules.jl
@@ -1,0 +1,40 @@
+function evalrule(f, p, lb, ub, nodes, weights)
+    scale = map((u, l) -> (u - l) / 2, ub, lb)
+    shift = (lb + ub) / 2
+    f_ = x -> f(x, p)
+    xw = ((map(*, scale, x) + shift, w) for (x, w) in zip(nodes, weights))
+    # we are basically computing sum(w .* f.(x))
+    # unroll first loop iteration to get right types
+    next = iterate(xw)
+    next === nothing && throw(ArgumentError("empty quadrature rule"))
+    (x0, w0), state = next
+    I = w0 * f_(x0)
+    next = iterate(xw, state)
+    while next !== nothing
+        (xi, wi), state = next
+        I += wi * f_(xi)
+        next = iterate(xw, state)
+    end
+    return prod(scale) * I
+end
+
+function init_cacheval(alg::QuadratureFunction, ::IntegralProblem)
+    return alg.q(alg.n)
+end
+
+function Integrals.__solvebp_call(cache::IntegralCache, alg::QuadratureFunction,
+    sensealg, lb, ub, p;
+    reltol = nothing, abstol = nothing,
+    maxiters = nothing)
+    prob = build_problem(cache)
+    if isinplace(prob)
+        error("QuadratureFunction does not support inplace integrandss.")
+    end
+    @assert prob.batch == 0
+    @assert prob.nout == 1
+
+    val = evalrule(cache.f, cache.p, lb, ub, cache.cacheval...)
+
+    err = nothing
+    SciMLBase.build_solution(prob, alg, val, err, retcode = ReturnCode.Success)
+end

--- a/test/quadrule_tests.jl
+++ b/test/quadrule_tests.jl
@@ -24,7 +24,7 @@ function trapz(n::Integer)
     return (x, w)
 end
 
-alg = QuadratureFunction(trapz, n = 1000)
+alg = QuadratureRule(trapz, n = 1000)
 
 lb = -1.2
 ub = 3.5
@@ -43,7 +43,7 @@ function trapz2(n)
     return [SVector(y, z) for (y, z) in Iterators.product(x, x)], w .* w'
 end
 
-alg = QuadratureFunction(trapz2, n = 100)
+alg = QuadratureRule(trapz2, n = 100)
 
 lb = SVector(-1.2, -1.0)
 ub = SVector(3.5, 3.7)
@@ -58,7 +58,7 @@ u = solve(prob, alg).u
 
 g = (x, p) -> p / (x^2 + p^2)
 
-alg = QuadratureFunction(gausslegendre, n = 1000)
+alg = QuadratureRule(gausslegendre, n = 1000)
 
 lb = -Inf
 ub = Inf
@@ -68,13 +68,28 @@ prob = IntegralProblem(g, lb, ub, p)
 
 @test solve(prob, alg).u≈pi rtol=1e-4
 
+# 1d with nout
+
+g2 = (x, p) -> [p[1] / (x^2 + p[1]^2), p[2] / (x^2 + p[2]^2)]
+
+alg = QuadratureRule(gausslegendre, n = 1000)
+
+lb = -Inf
+ub = Inf
+p = (1.0, 1.3)
+
+prob = IntegralProblem(g2, lb, ub, p)
+
+@test solve(prob, alg).u≈[pi,pi] rtol=1e-4
+
+
 #= derivative tests
 
 using Zygote
 
 function testf(lb, ub, p, f = f)
     prob = IntegralProblem(f, lb, ub, p)
-    solve(prob, QuadratureFunction(trapz, n=200))[1]
+    solve(prob, QuadratureRule(trapz, n=200))[1]
 end
 
 lb = -1.2

--- a/test/quadrule_tests.jl
+++ b/test/quadrule_tests.jl
@@ -80,8 +80,7 @@ p = (1.0, 1.3)
 
 prob = IntegralProblem(g2, lb, ub, p)
 
-@test solve(prob, alg).u≈[pi,pi] rtol=1e-4
-
+@test solve(prob, alg).u≈[pi, pi] rtol=1e-4
 
 #= derivative tests
 

--- a/test/quadrule_tests.jl
+++ b/test/quadrule_tests.jl
@@ -1,0 +1,87 @@
+using Integrals
+using FastGaussQuadrature
+using StaticArrays
+using Test
+
+f = (x, p) -> prod(y -> cos(p * y), x)
+exact_f = (lb, ub, p) -> prod(lu -> (sin(p * lu[2]) - sin(p * lu[1])) / p, zip(lb, ub))
+
+# single dim
+
+"""
+    trapz(n::Integer)
+
+Return the weights and nodes on the standard interval [-1,1] of the [trapezoidal
+rule](https://en.wikipedia.org/wiki/Trapezoidal_rule).
+"""
+function trapz(n::Integer)
+    @assert n > 1
+    r = range(-1, 1, length = n)
+    x = collect(r)
+    halfh = step(r) / 2
+    h = step(r)
+    w = [(i == 1) || (i == n) ? halfh : h for i in 1:n]
+    return (x, w)
+end
+
+alg = QuadratureFunction(trapz, n = 1000)
+
+lb = -1.2
+ub = 3.5
+p = 2.0
+
+prob = IntegralProblem(f, lb, ub, p)
+u = solve(prob, alg).u
+
+@test u≈exact_f(lb, ub, p) rtol=1e-3
+
+# multi-dim
+
+# here we just form a tensor product of 1d rules to make a 2d rule
+function trapz2(n)
+    x, w = trapz(n)
+    return [SVector(y, z) for (y, z) in Iterators.product(x, x)], w .* w'
+end
+
+alg = QuadratureFunction(trapz2, n = 100)
+
+lb = SVector(-1.2, -1.0)
+ub = SVector(3.5, 3.7)
+p = 1.2
+
+prob = IntegralProblem(f, lb, ub, p)
+u = solve(prob, alg).u
+
+@test u≈exact_f(lb, ub, p) rtol=1e-3
+
+# 1d with inf limits
+
+g = (x, p) -> p / (x^2 + p^2)
+
+alg = QuadratureFunction(gausslegendre, n = 1000)
+
+lb = -Inf
+ub = Inf
+p = 1.0
+
+prob = IntegralProblem(g, lb, ub, p)
+
+@test solve(prob, alg).u≈pi rtol=1e-4
+
+#= derivative tests
+
+using Zygote
+
+function testf(lb, ub, p, f = f)
+    prob = IntegralProblem(f, lb, ub, p)
+    solve(prob, QuadratureFunction(trapz, n=200))[1]
+end
+
+lb = -1.2
+ub = 2.0
+p = 3.1
+
+dp = Zygote.gradient(p -> testf(lb, ub, p), p)
+
+@test dp ≈ f(ub, p)-f(lb, p) rtol=1e-4
+=#

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,3 +22,6 @@ end
 @time @safetestset "Gaussian Quadrature Tests" begin
     include("gaussian_quadrature_tests.jl")
 end
+@time @safetest "QuadratureFunction Tests" begin
+    include("quadrule_tests.jl")
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,6 +22,6 @@ end
 @time @safetestset "Gaussian Quadrature Tests" begin
     include("gaussian_quadrature_tests.jl")
 end
-@time @safetest "QuadratureFunction Tests" begin
+@time @safetestset "QuadratureFunction Tests" begin
     include("quadrule_tests.jl")
 end


### PR DESCRIPTION
Hi,

This pr adds a `QuadratureFunction` algorithm that allows the user to pass in a function that returns nodes, `x`, and weights, `w`, and computes `sum(w .* f.(x))`. This could serve as a backend for other integration algorithms we would like to support, such as the trapezoidal rule and FastGaussQuadrature.jl rules.