### PR TITLE
Fix VEGAS interface

### DIFF
--- a/src/Integrals.jl
+++ b/src/Integrals.jl
@@ -161,9 +161,10 @@ function __solvebp_call(prob::IntegralProblem, alg::VEGAS, sensealg, domain, p;
     end
 
     ncalls = prob.f isa BatchIntegralFunction ? prob.f.max_batch : alg.ncalls
-    val, err, chi = vegas(f, lb, ub, rtol = reltol, atol = abstol,
+    out = vegas(f, lb, ub, rtol = reltol, atol = abstol,
         maxiter = maxiters, nbins = alg.nbins, debug = alg.debug,
         ncalls = ncalls, batch = prob.f isa BatchIntegralFunction)
+    val, err, chi = out isa Tuple ? out : (out.integral_estimate, out.standard_deviation, out.chi_squared_average)
     SciMLBase.build_solution(prob, alg, val, err, chi = chi, retcode = ReturnCode.Success)
 end
 

--- a/src/Integrals.jl
+++ b/src/Integrals.jl
@@ -135,9 +135,9 @@ function __solvebp_call(prob::IntegralProblem, alg::VEGAS, sensealg, domain, p;
             y = similar(prob.f.integrand_prototype,
                 size(prob.f.integrand_prototype)[begin:(end - 1)]...,
                 prob.f.max_batch)
-            # MonteCarloIntegration v0.0.x passes batches as columns of a matrix
+            # MonteCarloIntegration v0.0.x passes points as rows of a matrix
             # MonteCarloIntegration v0.1 passes batches as a vector of views of
-            # a matrix with batches as rows of a matrix
+            # a matrix with points as columns of a matrix
             # see https://github.com/ranjanan/MonteCarloIntegration.jl/issues/16
             # This is an ugly hack that is compatible with both
             f = x -> (prob.f(y, eltype(x) <: SubArray ? parent(first(x)) : x', p); vec(y))

--- a/src/Integrals.jl
+++ b/src/Integrals.jl
@@ -135,12 +135,17 @@ function __solvebp_call(prob::IntegralProblem, alg::VEGAS, sensealg, domain, p;
             y = similar(prob.f.integrand_prototype,
                 size(prob.f.integrand_prototype)[begin:(end - 1)]...,
                 prob.f.max_batch)
-            f = x -> (prob.f(y, x', p); vec(y))
+            # MonteCarloIntegration v0.0.x passes batches as columns of a matrix
+            # MonteCarloIntegration v0.1 passes batches as a vector of views of
+            # a matrix with batches as rows of a matrix
+            # see https://github.com/ranjanan/MonteCarloIntegration.jl/issues/16
+            # This is an ugly hack that is compatible with both
+            f = x -> (prob.f(y, eltype(x) <: SubArray ? parent(first(x)) : x', p); vec(y))
         else
             y = prob.f(mid isa Number ? typeof(mid)[] :
                        Matrix{eltype(mid)}(undef, length(mid), 0),
                 p)
-            f = x -> prob.f(x', p)
+            f = x -> prob.f(eltype(x) <: SubArray ? parent(first(x)) : x', p)
         end
     else
         if isinplace(prob)

--- a/src/Integrals.jl
+++ b/src/Integrals.jl
@@ -127,7 +127,7 @@ end
 
 function __solvebp_call(prob::IntegralProblem, alg::VEGAS, sensealg, domain, p;
         reltol = 1e-8, abstol = 1e-8,
-        maxiters = typemax(Int))
+        maxiters = 1000)
     lb, ub = domain
     mid = (lb + ub) / 2
     if prob.f isa BatchIntegralFunction

--- a/test/interface_tests.jl
+++ b/test/interface_tests.jl
@@ -7,7 +7,7 @@ max_nout_test = 2
 reltol = 1e-3
 abstol = 1e-3
 
-algs = [QuadGKJL(), HCubatureJL(), CubatureJLh(), CubatureJLp(), #VEGAS(), #CubaVegas(),
+algs = [QuadGKJL(), HCubatureJL(), CubatureJLh(), CubatureJLp(), VEGAS(), #CubaVegas(),
     CubaSUAVE(), CubaDivonne(), CubaCuhre()]
 
 alg_req = Dict(QuadGKJL() => (nout = 1, allows_batch = false, min_dim = 1, max_dim = 1,


### PR DESCRIPTION
Fixes #193 and adds VEGAS tests back into the test suite.
Should be compatible with both MonteCarloIntegration v0.1 and v0.0.3 based on running the tests locally, but only because of an ugly hack (see related issue https://github.com/ranjanan/MonteCarloIntegration.jl/issues/16 and comments in pr). 

Perhaps a better approach, since we added MonteCarloIntegration@0.1 only a day ago, is to drop support for it?