### PR TITLE
Add IntegralsArblibExt

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,7 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 
 [weakdeps]
+Arblib = "fb37089c-8514-4489-9461-98f9c8763369"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 Cuba = "8a292aeb-7a57-582c-b821-06e4c11590b1"
 Cubature = "667455a9-e2ce-5579-9412-b964f529a492"
@@ -22,6 +23,7 @@ ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [extensions]
+IntegralsArblib = "Arblib"
 IntegralsCubaExt = "Cuba"
 IntegralsCubatureExt = "Cubature"
 IntegralsFastGaussQuadratureExt = "FastGaussQuadrature"
@@ -29,6 +31,7 @@ IntegralsForwardDiffExt = "ForwardDiff"
 IntegralsZygoteExt = ["Zygote", "ChainRulesCore"]
 
 [compat]
+Arblib = "1"
 ChainRulesCore = "0.10.7, 1"
 CommonSolve = "0.2"
 Cuba = "2"
@@ -47,6 +50,7 @@ Zygote = "0.4.22, 0.5, 0.6"
 julia = "1.9"
 
 [extras]
+Arblib = "fb37089c-8514-4489-9461-98f9c8763369"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 Cuba = "8a292aeb-7a57-582c-b821-06e4c11590b1"
 Cubature = "667455a9-e2ce-5579-9412-b964f529a492"
@@ -62,4 +66,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["SciMLSensitivity", "StaticArrays", "FiniteDiff", "Pkg", "SafeTestsets", "Test", "Distributions", "ForwardDiff", "Zygote", "ChainRulesCore", "FastGaussQuadrature", "Cuba", "Cubature"]
+test = ["Arblib", "SciMLSensitivity", "StaticArrays", "FiniteDiff", "Pkg", "SafeTestsets", "Test", "Distributions", "ForwardDiff", "Zygote", "ChainRulesCore", "FastGaussQuadrature", "Cuba", "Cubature"]

--- a/Project.toml
+++ b/Project.toml
@@ -23,7 +23,7 @@ ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [extensions]
-IntegralsArblib = "Arblib"
+IntegralsArblibExt = "Arblib"
 IntegralsCubaExt = "Cuba"
 IntegralsCubatureExt = "Cubature"
 IntegralsFastGaussQuadratureExt = "FastGaussQuadrature"

--- a/docs/src/solvers/IntegralSolvers.md
+++ b/docs/src/solvers/IntegralSolvers.md
@@ -13,11 +13,18 @@ The following algorithms are available:
   - `CubaCuhre`: Cuhre from Cuba.jl. Requires `using Cuba`. Works only for `>1`-dimensional integrations.
   - `GaussLegendre`: Uses Gauss-Legendre quadrature with nodes and weights from FastGaussQuadrature.jl.
   - `QuadratureRule`: Accepts a user-defined function that returns nodes and weights.
+  - `ArblibJL`: real- and complex-valued univariate integration of holomorphic
+    and meromorphic functions from Arblib.jl. Requires `using Arblib`.
 
 ```@docs
 QuadGKJL
 HCubatureJL
 VEGAS
+CubaVegas
+CubaSUAVE
+CubaDivonne
+CubaCuhre
 GaussLegendre
 QuadratureRule
+ArblibJL
 ```

--- a/ext/IntegralArblib.jl
+++ b/ext/IntegralArblib.jl
@@ -1,0 +1,30 @@
+module IntegralsArblib
+
+using Arblib
+using Integrals
+
+function __solvebp_call(prob::IntegralProblem, alg::ArblibJL, sensealg, domain, p;
+    reltol = 1e-8, abstol = 1e-8, maxiters = typemax(Int))
+
+    lb, ub = domain
+    if lb isa AbstractArray || ub isa AbstractArray
+        error("QuadGKJL only accepts one-dimensional quadrature problems.")
+    end
+    @assert prob.f isa IntegralFunction
+
+    if isinplace(prob)
+        f_ = (y, x; kws...) -> prob.f(y, x, p; kws...)
+        val = Arblib.integrate!(f_, lb, ub, atol=abstol, rtol=reltol,
+            check_analytic=alg.check_analytic, take_prec=alg.take_prec,
+            warn_on_no_convergence=alg.warn_on_no_convergence, opts=alg.opts)
+        SciMLBase.build_solution(prob, alg, val, nothing, retcode = ReturnCode.Success)
+    else
+        f_ = (x; kws...) -> prob.f(x, p; kws...)
+        val = Arblib.integrate(f_, lb, ub, atol=abstol, rtol=reltol,
+            check_analytic=alg.check_analytic, take_prec=alg.take_prec,
+            warn_on_no_convergence=alg.warn_on_no_convergence, opts=alg.opts)
+        SciMLBase.build_solution(prob, alg, val, nothing, retcode = ReturnCode.Success)
+    end
+end
+
+end

--- a/ext/IntegralsArblibExt.jl
+++ b/ext/IntegralsArblibExt.jl
@@ -14,13 +14,14 @@ function Integrals.__solvebp_call(prob::IntegralProblem, alg::ArblibJL, sensealg
     @assert prob.f isa IntegralFunction
 
     if isinplace(prob)
-        f_ = (y, x; kws...) -> prob.f(y, x, p; kws...)
-        val = Arblib.integrate!(f_, lb, ub, atol=abstol, rtol=reltol,
+        y_ = similar(prob.f.integrand_prototype, typeof(Acb(0)))
+        f_ = (y, x; kws...) -> Arblib.set!(y, only(prob.f(y_, x, p; kws...)))
+        val = Arblib.integrate!(f_, Acb(0), lb, ub, atol=abstol, rtol=reltol,
             check_analytic=alg.check_analytic, take_prec=alg.take_prec,
             warn_on_no_convergence=alg.warn_on_no_convergence, opts=alg.opts)
         SciMLBase.build_solution(prob, alg, val, nothing, retcode = ReturnCode.Success)
     else
-        f_ = (x; kws...) -> prob.f(x, p; kws...)
+        f_ = (x; kws...) -> only(prob.f(x, p; kws...))
         val = Arblib.integrate(f_, lb, ub, atol=abstol, rtol=reltol,
             check_analytic=alg.check_analytic, take_prec=alg.take_prec,
             warn_on_no_convergence=alg.warn_on_no_convergence, opts=alg.opts)

--- a/ext/IntegralsArblibExt.jl
+++ b/ext/IntegralsArblibExt.jl
@@ -1,10 +1,10 @@
-module IntegralsArblib
+module IntegralsArblibExt
 
 using Arblib
 using Integrals
 
-function __solvebp_call(prob::IntegralProblem, alg::ArblibJL, sensealg, domain, p;
-    reltol = 1e-8, abstol = 1e-8, maxiters = typemax(Int))
+function Integrals.__solvebp_call(prob::IntegralProblem, alg::ArblibJL, sensealg, domain, p;
+    reltol = 1e-8, abstol = 1e-8, maxiters = nothing)
 
     lb, ub = domain
     if lb isa AbstractArray || ub isa AbstractArray

--- a/ext/IntegralsArblibExt.jl
+++ b/ext/IntegralsArblibExt.jl
@@ -6,9 +6,10 @@ using Integrals
 function Integrals.__solvebp_call(prob::IntegralProblem, alg::ArblibJL, sensealg, domain, p;
     reltol = 1e-8, abstol = 1e-8, maxiters = nothing)
 
-    lb, ub = domain
-    if lb isa AbstractArray || ub isa AbstractArray
-        error("QuadGKJL only accepts one-dimensional quadrature problems.")
+    lb_, ub_ = domain
+    lb, ub = map(first, domain)
+    if !isone(length(lb_)) || !isone(length(ub_))
+        error("ArblibJL only accepts one-dimensional quadrature problems.")
     end
     @assert prob.f isa IntegralFunction
 

--- a/ext/IntegralsArblibExt.jl
+++ b/ext/IntegralsArblibExt.jl
@@ -14,9 +14,10 @@ function Integrals.__solvebp_call(prob::IntegralProblem, alg::ArblibJL, sensealg
     @assert prob.f isa IntegralFunction
 
     if isinplace(prob)
-        y_ = similar(prob.f.integrand_prototype, typeof(Acb(0)))
+        res = Acb(0)
+        y_ = similar(prob.f.integrand_prototype, typeof(res))
         f_ = (y, x; kws...) -> Arblib.set!(y, only(prob.f(y_, x, p; kws...)))
-        val = Arblib.integrate!(f_, Acb(0), lb, ub, atol=abstol, rtol=reltol,
+        val = Arblib.integrate!(f_, res, lb, ub, atol=abstol, rtol=reltol,
             check_analytic=alg.check_analytic, take_prec=alg.take_prec,
             warn_on_no_convergence=alg.warn_on_no_convergence, opts=alg.opts)
         SciMLBase.build_solution(prob, alg, val, nothing, retcode = ReturnCode.Success)

--- a/src/Integrals.jl
+++ b/src/Integrals.jl
@@ -177,5 +177,6 @@ end
 export QuadGKJL, HCubatureJL, VEGAS, GaussLegendre, QuadratureRule, TrapezoidalRule
 export CubaVegas, CubaSUAVE, CubaDivonne, CubaCuhre
 export CubatureJLh, CubatureJLp
+export ArblibJL
 
 end # module

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -344,3 +344,29 @@ Defaults to `Cubature.INDIVIDUAL`, other options are
 struct CubatureJLp <: AbstractCubatureJLAlgorithm
     error_norm::Int32
 end
+
+
+"""
+    ArblibJL(; check_analytic=false, take_prec=false, warn_on_no_convergence=false, opts=C_NULL)
+
+One-dimensional adaptive Gauss-Legendre integration using rigorous error bounds and
+precision ball arithmetic. Generally this assumes the integrand is holomorphic or
+meromorphic, which is the user's responsibility to verify. The result of the integral is not
+guaranteed to satisfy the requested tolerances, however the result is guaranteed to be
+within the error estimate.
+
+[Arblib.jl](https://github.com/kalmarek/Arblib.jl) only supports integration of univariate
+real- and complex-valued functions with both inplace and out-of-place forms. See their
+documentation for additional details the algorithm arguments and on implementing
+high-precision integrands. Additionally, the error estimate is included in the return value
+of the integral, representing a ball.
+"""
+struct ArblibJL{O} <: SciMLBase.AbstractIntegralAlgorithm
+    check_analytic::Bool
+    take_prec::Bool
+    warn_on_no_convergence::Bool
+    opts::O
+end
+function ArblibJL(; check_analytic=false, take_prec=false, warn_on_no_convergence=false, opts=C_NULL)
+    return ArblibJL(check_analytic, take_prec, warn_on_no_convergence, opts)
+end

--- a/test/interface_tests.jl
+++ b/test/interface_tests.jl
@@ -8,7 +8,7 @@ reltol = 1e-3
 abstol = 1e-3
 
 algs = [QuadGKJL, HCubatureJL, CubatureJLh, CubatureJLp, VEGAS, #CubaVegas,
-    CubaSUAVE, CubaDivonne, CubaCuhre]
+    CubaSUAVE, CubaDivonne, CubaCuhre, Arblib]
 
 alg_req = Dict(QuadGKJL => (nout = 1, allows_batch = false, min_dim = 1, max_dim = 1,
         allows_iip = false),
@@ -27,7 +27,8 @@ alg_req = Dict(QuadGKJL => (nout = 1, allows_batch = false, min_dim = 1, max_dim
     CubaDivonne => (nout = Inf, allows_batch = true, min_dim = 2,
         max_dim = Inf, allows_iip = true),
     CubaCuhre => (nout = Inf, allows_batch = true, min_dim = 2, max_dim = Inf,
-        allows_iip = true))
+        allows_iip = true),
+    Arblib => (nout=1, allows_batch=false, min_dim=1, max_dim=1, allows_iip=true))
 
 integrands = [
     (x, p) -> 1.0,

--- a/test/interface_tests.jl
+++ b/test/interface_tests.jl
@@ -1,5 +1,5 @@
 using Integrals
-using Cuba, Cubature
+using Cuba, Cubature, Arblib
 using Test
 
 max_dim_test = 2
@@ -8,7 +8,7 @@ reltol = 1e-3
 abstol = 1e-3
 
 algs = [QuadGKJL, HCubatureJL, CubatureJLh, CubatureJLp, VEGAS, #CubaVegas,
-    CubaSUAVE, CubaDivonne, CubaCuhre, Arblib]
+    CubaSUAVE, CubaDivonne, CubaCuhre, ArblibJL]
 
 alg_req = Dict(QuadGKJL => (nout = 1, allows_batch = false, min_dim = 1, max_dim = 1,
         allows_iip = false),
@@ -28,7 +28,7 @@ alg_req = Dict(QuadGKJL => (nout = 1, allows_batch = false, min_dim = 1, max_dim
         max_dim = Inf, allows_iip = true),
     CubaCuhre => (nout = Inf, allows_batch = true, min_dim = 2, max_dim = Inf,
         allows_iip = true),
-    Arblib => (nout=1, allows_batch=false, min_dim=1, max_dim=1, allows_iip=true))
+    ArblibJL => (nout=1, allows_batch=false, min_dim=1, max_dim=1, allows_iip=true))
 
 integrands = [
     (x, p) -> 1.0,


### PR DESCRIPTION
This pr adds an extension for the recently-released [Arblib.jl](https://github.com/kalmarek/Arblib.jl) package (v1) with high-precision integration routines for holomorphic functions. Although the package is somewhat limited (i.e. no vector integrands or batching) I think it would be interesting to have alongside other algorithms.

I am not a user of Arblib.jl so I may have made a mistake in the implementation regarding the handling of the special number types in the package. In particular, the result type is a number containing the error estimate, instead of the integral and error estimate being separate like other Integrals.jl algorithms