### PR TITLE
Small fix for composite Gauss-Legendre quadrature with array-valued integrands

### DIFF
--- a/ext/IntegralsFastGaussQuadratureExt.jl
+++ b/ext/IntegralsFastGaussQuadratureExt.jl
@@ -26,9 +26,9 @@ function gauss_legendre(f::F, p, lb, ub, nodes, weights) where {F}
 end
 function composite_gauss_legendre(f::F, p, lb, ub, nodes, weights, subintervals) where {F}
     h = (ub - lb) / subintervals
-    I = zero(h)
-    for i in 1:subintervals
-        _lb = lb + (i - 1) * h
+    I = gauss_legendre(f, p, lb, lb + h, nodes, weights)
+    for i in 1:subintervals-1
+        _lb = lb + i * h
         _ub = _lb + h
         I += gauss_legendre(f, p, _lb, _ub, nodes, weights)
     end

--- a/test/derivative_tests.jl
+++ b/test/derivative_tests.jl
@@ -15,6 +15,8 @@ alg_req = Dict(
         allows_iip = false),
     GaussLegendre(n = 50) => (nout = Inf, min_dim = 1, max_dim = 1, allows_batch = false,
         allows_iip = false),
+    GaussLegendre(n = 50, subintervals=3) => (nout = Inf, min_dim = 1, max_dim = 1, allows_batch = false,
+        allows_iip = false),
     QuadGKJL() => (nout = Inf, allows_batch = true, min_dim = 1, max_dim = 1,
         allows_iip = true),
     HCubatureJL() => (nout = Inf, allows_batch = false, min_dim = 1,

--- a/test/gaussian_quadrature_tests.jl
+++ b/test/gaussian_quadrature_tests.jl
@@ -97,3 +97,21 @@ sol = solve(prob, alg)
 alg = GaussLegendre(n = 500, subintervals = 17)
 sol = solve(prob, alg)
 @test sol.u ≈ -240.25235266303063249920743158729
+
+# Gauss-Legendre with array-valued integrands
+prob = IntegralProblem((x,p)->[1,2], (-1,1))
+sol = solve(prob, GaussLegendre(;n=5))
+@test sol.u ≈ 2*[1,2]
+
+prob = IntegralProblem((x,p)->[1 2; 3 4], (-1,1))
+sol = solve(prob, GaussLegendre(;n=5))
+@test sol.u ≈ 2*[1 2; 3 4]
+
+# Composite Gauss-Legendre with array-valued integrands
+prob = IntegralProblem((x,p)->[1,2], (-1,1))
+sol = solve(prob, GaussLegendre(;n=5, subintervals=5))
+@test sol.u ≈ 2*[1,2]
+
+prob = IntegralProblem((x,p)->[1 2; 3 4], (-1,1))
+sol = solve(prob, GaussLegendre(;n=5, subintervals=5))
+@test sol.u ≈ 2*[1 2; 3 4]


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Currently composite Gauss-Legendre quadrature fails with array-valued integrals. Consequently, it also breaks parametric derivatives over Integrals.jl interface with composite Gauss-Legendre quadrature. This is due to an assumption on the integrand result type [here](https://github.com/SciML/Integrals.jl/blob/7927a46be82b8e362808b626c4bf7a36cce5296c/ext/IntegralsFastGaussQuadratureExt.jl#L29). Tests have been added to cover this context.
