### PR TITLE
Remove Julia v1.9 get_extension compatibility code

### DIFF
--- a/ext/IntegralsFastGaussQuadratureExt.jl
+++ b/ext/IntegralsFastGaussQuadratureExt.jl
@@ -1,6 +1,5 @@
 module IntegralsFastGaussQuadratureExt
 using Integrals
-if isdefined(Base, :get_extension)
     import FastGaussQuadrature
     import FastGaussQuadrature: gausslegendre
     # and eventually gausschebyshev, etc.

--- a/ext/IntegralsFastGaussQuadratureExt.jl
+++ b/ext/IntegralsFastGaussQuadratureExt.jl
@@ -1,12 +1,8 @@
 module IntegralsFastGaussQuadratureExt
 using Integrals
-    import FastGaussQuadrature
-    import FastGaussQuadrature: gausslegendre
-    # and eventually gausschebyshev, etc.
-else
-    import ..FastGaussQuadrature
-    import ..FastGaussQuadrature: gausslegendre
-end
+import FastGaussQuadrature
+import FastGaussQuadrature: gausslegendre
+
 using LinearAlgebra
 
 Integrals.gausslegendre(n) = FastGaussQuadrature.gausslegendre(n)

--- a/ext/IntegralsForwardDiffExt.jl
+++ b/ext/IntegralsForwardDiffExt.jl
@@ -1,6 +1,6 @@
 module IntegralsForwardDiffExt
 using Integrals
-isdefined(Base, :get_extension) ? (using ForwardDiff) : (using ..ForwardDiff)
+using ForwardDiff
 ### Forward-Mode AD Intercepts
 
 function Integrals._evaluate!(f, y, u,

--- a/ext/IntegralsZygoteExt.jl
+++ b/ext/IntegralsZygoteExt.jl
@@ -1,7 +1,6 @@
 module IntegralsZygoteExt
 using LinearAlgebra: dot
 using Integrals
-if isdefined(Base, :get_extension)
     using Zygote
     import ChainRulesCore
     import ChainRulesCore: Tangent, NoTangent, ProjectTo

--- a/ext/IntegralsZygoteExt.jl
+++ b/ext/IntegralsZygoteExt.jl
@@ -1,14 +1,10 @@
 module IntegralsZygoteExt
 using LinearAlgebra: dot
 using Integrals
-    using Zygote
-    import ChainRulesCore
-    import ChainRulesCore: Tangent, NoTangent, ProjectTo
-else
-    using ..Zygote
-    import ..Zygote.ChainRulesCore
-    import ..Zygote.ChainRulesCore: Tangent, NoTangent, ProjectTo
-end
+using Zygote
+import ChainRulesCore
+import ChainRulesCore: Tangent, NoTangent, ProjectTo
+
 ChainRulesCore.@non_differentiable Integrals.checkkwargs(kwargs...)
 ChainRulesCore.@non_differentiable Integrals.isinplace(f, args...)    # fixes #99
 ChainRulesCore.@non_differentiable Integrals.init_cacheval(alg, prob)

--- a/src/Integrals.jl
+++ b/src/Integrals.jl
@@ -1,9 +1,5 @@
 module Integrals
 
-if !isdefined(Base, :get_extension)
-    using Requires
-end
-
 using Reexport, MonteCarloIntegration, QuadGK, HCubature
 @reexport using SciMLBase
 using LinearAlgebra


### PR DESCRIPTION
## Description

This PR removes the compatibility checks for `isdefined(Base, :get_extension)` since all SciML packages now require Julia v1.10+, where package extensions are built-in.

## Changes

- Removed unnecessary version checks in extension loading code
- Simplified extension imports by removing conditional logic
- Cleaned up obsolete compatibility code

## Context

As identified in the SciML-wide analysis, all SciML packages have moved to requiring Julia v1.10+ as the minimum version. This makes the compatibility code for checking whether package extensions are available redundant.

The `isdefined(Base, :get_extension)` checks were used to support Julia v1.9 where extensions were loaded differently. Since we no longer support v1.9, this code can be safely removed.

## Testing

- [ ] Package tests pass locally
- [ ] No changes to functionality, only removal of version checks