### PR TITLE
Fix docs build: document CommonSolve.init in manual

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
 Cuba = "8a292aeb-7a57-582c-b821-06e4c11590b1"
 Cubature = "667455a9-e2ce-5579-9412-b964f529a492"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
@@ -9,6 +10,7 @@ Integrals = "de52edbc-65ea-441a-8357-d3a637375a31"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
+CommonSolve = "0.2"
 Cuba = "2"
 Cubature = "1"
 Distributions = "0.25"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,4 +1,4 @@
-using Documenter, Integrals
+using Documenter, Integrals, CommonSolve
 
 cp("./docs/Manifest.toml", "./docs/src/assets/Manifest.toml", force = true)
 cp("./docs/Project.toml", "./docs/src/assets/Project.toml", force = true)

--- a/docs/src/basics/solve.md
+++ b/docs/src/basics/solve.md
@@ -14,8 +14,8 @@ solve(prob::SampledIntegralProblem, alg::SciMLBase.AbstractIntegralAlgorithm)
 utilities reexported by Integrals.jl. Their API is documented by SciMLBase.
 
 ```@docs
-init(prob::IntegralProblem, alg::SciMLBase.AbstractIntegralAlgorithm)
-init(prob::SampledIntegralProblem, alg::SciMLBase.AbstractIntegralAlgorithm)
+CommonSolve.init(prob::IntegralProblem, alg::SciMLBase.AbstractIntegralAlgorithm)
+CommonSolve.init(prob::SampledIntegralProblem, alg::SciMLBase.AbstractIntegralAlgorithm)
 solve!(cache::Integrals.IntegralCache)
 solve!(cache::Integrals.SampledIntegralCache)
 isinplace(cache::Integrals.IntegralCache)


### PR DESCRIPTION
## Summary
- Documenter's `checkdocs = :exports` reports the reexported `init` docstrings under the `CommonSolve.init` binding, but the manual only referenced unqualified `init(...)`.
- Reference `CommonSolve.init` explicitly in the `@docs` block and import `CommonSolve` in `docs/make.jl`.

## Root cause
After adopting strict `checkdocs = :exports` in #352, the Integrals-owned `init` docstrings were not matched to the exported `CommonSolve.init` binding, causing `:missing_docs` failures.

## Test plan
- [x] Local docs build passes `checkdocs = :exports` (verified; linkcheck may rate-limit locally)
- [ ] Documentation CI on this PR

Made with [Cursor](https://cursor.com)