### PR TITLE
Require LatticeRules 0.0.2 (32-bit LatticeRule32)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -46,6 +46,7 @@ IntegralsMooncakeExt = ["Mooncake", "Zygote", "ChainRulesCore"]
 IntegralsZygoteExt = ["Zygote", "ZygoteRules", "ChainRulesCore"]
 
 [compat]
+LatticeRules = "0.0.2"
 ADTypes = "1.22.0"
 Arblib = "1"
 ArrayInterface = "7.9.0"
@@ -80,6 +81,7 @@ ZygoteRules = "0.2.5"
 julia = "1.10"
 
 [extras]
+LatticeRules = "73f95e8e-ec14-4e6a-8b18-0d2e271c4e55"
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 Arblib = "fb37089c-8514-4489-9461-98f9c8763369"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
@@ -98,4 +100,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["ADTypes", "Arblib", "StaticArrays", "SafeTestsets", "SciMLTesting", "Test", "Distributions", "ChainRulesCore", "FastGaussQuadrature", "FastTanhSinhQuadrature", "Cuba", "Cubature", "MCIntegration", "DifferentiationInterface", "HAdaptiveIntegration", "Unitful"]
+test = ["LatticeRules", "ADTypes", "Arblib", "StaticArrays", "SafeTestsets", "SciMLTesting", "Test", "Distributions", "ChainRulesCore", "FastGaussQuadrature", "FastTanhSinhQuadrature", "Cuba", "Cubature", "MCIntegration", "DifferentiationInterface", "HAdaptiveIntegration", "Unitful"]


### PR DESCRIPTION
## Summary
Force LatticeRules ≥0.0.2 so QuasiMonteCarlo LatticeRuleSample precompile works on i686 (0.0.1 rejects `typemax(UInt32)+1`-style bounds).

## Test plan
- [ ] x86 Core green

Made with [Cursor](https://cursor.com)