### PR TITLE
CI: i686 gitconfig tip for MCI URL [sources]

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,5 +12,5 @@ on:
       - 'docs/**'
 jobs:
   tests:
-    uses: "SciML/.github/.github/workflows/grouped-tests.yml@master"
+    uses: "ChrisRackauckas-Claude/.github/.github/workflows/grouped-tests.yml@i686-gitconfig-consumable"
     secrets: "inherit"

--- a/docs/src/basics/solve.md
+++ b/docs/src/basics/solve.md
@@ -4,8 +4,8 @@
 implements it for integral problems and the algorithms documented on this site.
 
 ```@docs
-solve(prob::IntegralProblem, alg::SciMLBase.AbstractIntegralAlgorithm)
-solve(prob::SampledIntegralProblem, alg::SciMLBase.AbstractIntegralAlgorithm)
+solve(::IntegralProblem, ::SciMLBase.AbstractIntegralAlgorithm)
+solve(::SampledIntegralProblem, ::SciMLBase.AbstractIntegralAlgorithm)
 ```
 
 ## Related SciML interface utilities
@@ -14,9 +14,9 @@ solve(prob::SampledIntegralProblem, alg::SciMLBase.AbstractIntegralAlgorithm)
 utilities reexported by Integrals.jl. Their API is documented by SciMLBase.
 
 ```@docs
-CommonSolve.init(prob::IntegralProblem, alg::SciMLBase.AbstractIntegralAlgorithm)
-CommonSolve.init(prob::SampledIntegralProblem, alg::SciMLBase.AbstractIntegralAlgorithm)
-solve!(cache::Integrals.IntegralCache)
-solve!(cache::Integrals.SampledIntegralCache)
-isinplace(cache::Integrals.IntegralCache)
+CommonSolve.init(::IntegralProblem, ::SciMLBase.AbstractIntegralAlgorithm)
+CommonSolve.init(::SampledIntegralProblem, ::SciMLBase.AbstractIntegralAlgorithm)
+solve!(::Integrals.IntegralCache)
+solve!(::Integrals.SampledIntegralCache)
+isinplace(::Integrals.IntegralCache)
 ```


### PR DESCRIPTION
## Summary
- Master x86 fails cloning MCI URL `[sources]` (`failed to stat '/etc/gitconfig'`).
- Point CI at `ChrisRackauckas-Claude/.github@i686-gitconfig-consumable` (carries the i686 gitconfig + clone cleanup from SciML/.github#137 before that PR merges).
- After [#137](https://github.com/SciML/.github/pull/137) merges, switch this back to `SciML/.github@master` and drop once MCI 0.3.0 registers.

## Test plan
- [ ] x86 Core green with MCI URL source
- [ ] Revert workflow pin after `.github#137` lands


Made with [Cursor](https://cursor.com)