### PR TITLE
Drop the MonteCarloIntegration [sources] override; release 5.5.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Integrals"
 uuid = "de52edbc-65ea-441a-8357-d3a637375a31"
-version = "5.5.0"
+version = "5.5.1"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]
@@ -100,5 +100,3 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 [targets]
 test = ["ADTypes", "Arblib", "StaticArrays", "SafeTestsets", "SciMLTesting", "Test", "Distributions", "ChainRulesCore", "FastGaussQuadrature", "FastTanhSinhQuadrature", "Cuba", "Cubature", "MCIntegration", "DifferentiationInterface", "HAdaptiveIntegration", "Unitful"]
 
-[sources]
-MonteCarloIntegration = {url = "https://github.com/ranjanan/MonteCarloIntegration.jl.git", rev = "master"}


### PR DESCRIPTION
`MonteCarloIntegration` 0.3.0 is now in the General registry, so the git-URL override can go:

```toml
[sources]
MonteCarloIntegration = {url = "https://github.com/ranjanan/MonteCarloIntegration.jl.git", rev = "master"}
```

The existing compat entry is already `MonteCarloIntegration = "0.2, 0.3"`, so resolution now comes from the registry with no other change needed. Version bumped 5.5.0 -> 5.5.1.

## Why the override existed, and why it can go now

MonteCarloIntegration 0.3.0 has been sitting unregistered since 2026-08-27, so Integrals reached the code by git URL instead. That override is what broke the i686 lane, which could not clone it:

```
failed to stat '/etc/gitconfig'
```

That is the failure #367 was opened to work around, and its own description says to drop it "once MCI 0.3.0 registers".

Unblocking the registration took three steps, because the package had moved from `ranjanan/MonteCarloIntegration.jl` to `SciML/MonteCarloIntegration.jl`:

1. Registrator refused every attempt with `Changing package repo URL not allowed`, since General still recorded the old URL.
2. JuliaRegistries/General#167927 corrected the `repo` field.
3. 0.3.0 then registered via JuliaRegistries/General#167966.

The earlier attempt, JuliaRegistries/General#166242, had stalled for a different reason: AutoMerge wanted breaking release notes and the agent working it was not a collaborator on the personal repository. The move to SciML resolved that.

## Follow-up

#367 should be closable once this lands and the x86 lane is green without the override.

## What was not verified

No test suite was run locally. This changes `Project.toml` only, removing a dependency source override and bumping the version. The meaningful check is that CI, and specifically the x86 lane, resolves MonteCarloIntegration from the registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R