### PR TITLE
Drop `/` from the `LinearAlgebra` import

### DIFF
--- a/src/Integrals.jl
+++ b/src/Integrals.jl
@@ -9,7 +9,7 @@ using HCubature: HCubature, hcubature, hquadrature
     IntegralProblem, SampledIntegralProblem, ReturnCode,
     isinplace, remake, init, solve!, solve
 using SciMLBase: init, solve!
-using LinearAlgebra: LinearAlgebra, /, norm
+using LinearAlgebra: LinearAlgebra, norm
 using Random: Random
 using ArrayInterface: ArrayInterface
 using SciMLLogging: SciMLLogging, @SciMLMessage, MessageLevel, Silent,


### PR DESCRIPTION
## Summary

The QA job on the `julia '1'` lane (Julia 1.13.0) fails two ExplicitImports checks because `/` is imported from `LinearAlgebra`, while its owner is `Base`:

- `all_explicit_imports_via_owners`: `` `/` has owner `Base` but it was imported from `LinearAlgebra` ``
- `all_explicit_imports_are_public`: `` `/` is not public in `LinearAlgebra` ``

Failing run: https://github.com/SciML/Integrals.jl/actions/runs/34684533841

`/` is only called, never extended, and `Base` exports it — dropped from the import list. `norm` stays.

## Remaining QA failures (not addressed here)

The JET opt-mode testset in `test/qa/qa.jl` still fails on Julia 1.13 for `HCubatureJL` and `VEGAS`. Under JET 0.11.x these are runtime-dispatch reports in the solver call paths; under JET 0.12.1, `VEGAS` passes but `HCubatureJL` analysis crashes inside JET itself (`Base.BottomRF{typeof(*)} not supported` in `typeof_arg`) — an upstream JET-on-1.13 bug, not an Integrals dispatch. Needs a JET fix or an adjusted expectation once JET supports the analysis; left out of this PR.

## Test plan

- [x] `run_qa` suite passes 21/21 on Julia 1.13.0 (the two EI checks errored in CI on the unfixed code)
- [ ] CI

🤖 Generated with Devin CLI 3000.10.21 (model: SWE-2 Max). Session: local session, `/home/crackauc/.local/share/devin/cli/sessions.db`