### PR TITLE
Fix the CommonSolve.init @docs signature for the parametric method

### DIFF
--- a/docs/src/basics/solve.md
+++ b/docs/src/basics/solve.md
@@ -14,7 +14,7 @@ solve(::SampledIntegralProblem, ::SciMLBase.AbstractIntegralAlgorithm)
 utilities reexported by Integrals.jl. Their API is documented by SciMLBase.
 
 ```@docs
-CommonSolve.init(::IntegralProblem, ::SciMLBase.AbstractIntegralAlgorithm)
+CommonSolve.init(::IntegralProblem{iip}, ::SciMLBase.AbstractIntegralAlgorithm) where {iip}
 CommonSolve.init(::SampledIntegralProblem, ::SciMLBase.AbstractIntegralAlgorithm)
 solve!(::Integrals.IntegralCache)
 solve!(::Integrals.SampledIntegralCache)


### PR DESCRIPTION
## Summary

The Documentation job on master fails `checkdocs = :exports` with:

```
Error: 1 docstring not included in the manual:
    CommonSolve.init :: Union{Tuple{iip}, Tuple{IntegralProblem{iip}, SciMLBase.AbstractIntegralAlgorithm}} where iip
```

The `@docs` entry in `docs/src/basics/solve.md` was written as `CommonSolve.init(::IntegralProblem, ::SciMLBase.AbstractIntegralAlgorithm)`, which produces signature `Tuple{IntegralProblem, AbstractIntegralAlgorithm}`. The docstring is attached to the parametric method `init(::IntegralProblem{iip}, ...) where iip`, stored under the `Union{Tuple{iip}, Tuple{IntegralProblem{iip}, AbstractIntegralAlgorithm}} where iip` signature — the two do not compare equal, so Documenter reports it missing. Writing the typevar explicitly in the `@docs` entry makes the signature match.

## Test plan

- [x] Confirmed `Core.eval(Integrals, Base.Docs.signature(...))` on the new entry is `===`-equal to the stored docstring signature; the old entry matches nothing
- [x] `julia --project=docs docs/make.jl` completes CheckDocument cleanly with no missing-docs error

🤖 Generated with [Devin](https://devin.ai) — Agent-Harness: Devin CLI 3000.10.21, Agent-Model: SWE-2 Max, Agent-Session: /home/crackauc/.local/share/devin/cli/summaries/history_4c9fddb81d834736.md (local session transcript; no shareable URL)