### PR TITLE
Keep the JET solver-path QA checks live on Julia 1.13

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -89,12 +89,21 @@ run_qa(
     @testset "HCubatureJL" begin
         f = (x, p) -> x[1]^2 + x[2]^2
         prob = IntegralProblem(f, ([0.0, 0.0], [1.0, 1.0]))
-        rep = @report_opt target_modules = (Integrals,) solve(prob, HCubatureJL())
-        # JET's opt-mode analyzer misinterprets 1.13 optimized IR: it reports runtime
-        # dispatch on fully concrete code here (and crashes outright on JET 0.12+,
-        # https://github.com/aviatesk/JET.jl/issues/863). Native `Base.return_types`
-        # on this path is concrete on 1.12 and 1.13.
-        @test length(JET.get_reports(rep)) == 0 broken = VERSION >= v"1.13"
+        if VERSION < v"1.13.0-"
+            rep = @report_opt target_modules = (Integrals,) solve(prob, HCubatureJL())
+            @test length(JET.get_reports(rep)) == 0
+        else
+            # JET's optanalyzer does not yet model Julia 1.13 optimized IR: 0.11
+            # reports runtime dispatch at call sites Base's own optimized IR shows
+            # concrete, and 0.12+ crashes outright
+            # (https://github.com/aviatesk/JET.jl/issues/863). Until that is fixed
+            # upstream, guard this path with JET's call analyzer (unoptimized-IR
+            # method errors, unaffected on 1.13) plus the native inference result.
+            rep = @report_call target_modules = (Integrals,) solve(prob, HCubatureJL())
+            @test length(JET.get_reports(rep)) == 0
+            rt = only(Base.return_types(solve, Tuple{typeof(prob), HCubatureJL}))
+            @test rt <: SciMLBase.IntegralSolution{Float64}
+        end
     end
 
     @testset "SampledIntegralProblem with TrapezoidalRule" begin
@@ -127,11 +136,16 @@ run_qa(
         # We verify the number of issues is bounded and doesn't regress.
         f = (x, p) -> x^2
         prob = IntegralProblem(f, (0.0, 1.0))
-        rep = @report_opt target_modules = (Integrals,) solve(prob, VEGAS())
-        # JET's opt-mode analyzer misinterprets 1.13 optimized IR: it reports runtime
-        # dispatch on fully concrete code here (and crashes outright on JET 0.12+,
-        # https://github.com/aviatesk/JET.jl/issues/863). Native `Base.return_types`
-        # on this path is concrete on 1.12 and 1.13.
-        @test length(JET.get_reports(rep)) <= 2 broken = VERSION >= v"1.13"
+        if VERSION < v"1.13.0-"
+            rep = @report_opt target_modules = (Integrals,) solve(prob, VEGAS())
+            @test length(JET.get_reports(rep)) <= 2
+        else
+            # See the HCubatureJL testset above: JET's optanalyzer cannot analyze
+            # 1.13 optimized IR, so use its call analyzer and native inference.
+            rep = @report_call target_modules = (Integrals,) solve(prob, VEGAS())
+            @test length(JET.get_reports(rep)) == 0
+            rt = only(Base.return_types(solve, Tuple{typeof(prob), VEGAS}))
+            @test rt <: SciMLBase.IntegralSolution{Float64}
+        end
     end
 end

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -90,7 +90,11 @@ run_qa(
         f = (x, p) -> x[1]^2 + x[2]^2
         prob = IntegralProblem(f, ([0.0, 0.0], [1.0, 1.0]))
         rep = @report_opt target_modules = (Integrals,) solve(prob, HCubatureJL())
-        @test length(JET.get_reports(rep)) == 0
+        # JET's opt-mode analyzer misinterprets 1.13 optimized IR: it reports runtime
+        # dispatch on fully concrete code here (and crashes outright on JET 0.12+,
+        # https://github.com/aviatesk/JET.jl/issues/863). Native `Base.return_types`
+        # on this path is concrete on 1.12 and 1.13.
+        @test length(JET.get_reports(rep)) == 0 broken = VERSION >= v"1.13"
     end
 
     @testset "SampledIntegralProblem with TrapezoidalRule" begin
@@ -124,6 +128,10 @@ run_qa(
         f = (x, p) -> x^2
         prob = IntegralProblem(f, (0.0, 1.0))
         rep = @report_opt target_modules = (Integrals,) solve(prob, VEGAS())
-        @test length(JET.get_reports(rep)) <= 2
+        # JET's opt-mode analyzer misinterprets 1.13 optimized IR: it reports runtime
+        # dispatch on fully concrete code here (and crashes outright on JET 0.12+,
+        # https://github.com/aviatesk/JET.jl/issues/863). Native `Base.return_types`
+        # on this path is concrete on 1.12 and 1.13.
+        @test length(JET.get_reports(rep)) <= 2 broken = VERSION >= v"1.13"
     end
 end


### PR DESCRIPTION
## Summary

The `JET opt-mode solver paths` testset in `test/qa/qa.jl` fails on Julia 1.13 for `HCubatureJL` (expects 0 reports, gets 7) and `VEGAS` (expects ≤2, gets more). Investigation shows this is a **JET-on-1.13 analyzer bug**, not an Integrals defect:

- Julia's own optimized IR for `solve(prob, HCubatureJL())` is identical on 1.12.7 and 1.13.0 (`code_typed(...; optimize = true)`): same inferred return type, and none of the widened types JET reports (e.g. `Union{Vector{Float64}, Vector{Int64}, Vector{Real}}`) appear anywhere in Base's IR. The widening exists only inside JET's own re-analysis.
- **JET 0.11.6** (what CI resolves) emits false-positive `RuntimeDispatchReport`s — the same class documented upstream in https://github.com/aviatesk/JET.jl/issues/839.
- **JET 0.12+** *crashes outright* on the same analysis — `typeof_arg` does not support the `Base.BottomRF` nodes that 1.13's optimizer emits for `prod`/`mapfoldl` reductions. Filed upstream as https://github.com/aviatesk/JET.jl/issues/863 with a reproducer.

This PR keeps the checks **live on every Julia version** instead of marking them broken:

- On Julia < 1.13: unchanged — the `@report_opt` bounds (0 reports for `HCubatureJL`, ≤2 for `VEGAS`) still run.
- On Julia ≥ 1.13 (including prereleases, via `VERSION < v"1.13.0-"`): the same solver calls are checked with `@report_call` — JET's call analyzer over unoptimized IR, which is unaffected by the optimized-IR issue and catches method errors / undefined-variable defects through the whole path — plus a native-inference assertion that `solve` infers to `SciMLBase.IntegralSolution{Float64}`.

The four opt-mode testsets that still pass on 1.13 (`QuadGKJL`, `SampledIntegralProblem` ×2, scalar infinite bounds) are left strict on all versions.

## Alternatives considered

- `broken = VERSION >= v"1.13"`: silences the only coverage on these paths for every 1.13.x release — a real method error or inference regression would go unnoticed until JET is fixed upstream. Rejected in favor of live checks.
- Hard version-gate with no replacement: same hole, plus no signal when upstream JET recovers.
- *Rewriting `substitute_u`/`substitute_v` to dodge JET's widening*: JET then reports deeper artifacts (it widens HCubature's integration point to `Union{BitVector, Vector}`, making the transformed-integrand closure `Any` internally). Not bounded or fixable package-side.

## Test plan

- [x] `JET opt-mode solver paths` testset on Julia 1.13.0 + JET 0.11.6: **8/8 pass** on the new branch (`@report_call` clean, return-type assertions hold)
- [x] Same testset on Julia 1.12.7 + JET 0.11.6: **6/6 pass** on the JET opt-mode branch (unchanged behavior)
- [x] `Base.code_typed` on `solve(prob, HCubatureJL())` is identical on 1.12.7 and 1.13.0 — the `Union{Vector{Float64}, Vector{Int64}, Vector{Real}}` JET reports is absent from Base IR
- [x] `runic` clean on `test/qa/qa.jl`
- [ ] CI QA group

🤖 Generated with [Devin](https://devin.ai) (model: SWE-2 Max)
Session: local transcript — /home/crackauc/.local/share/devin/cli/summaries/history_049e4e367a5d4d70.md (no shareable URL for this harness)
